### PR TITLE
Events Home Page done

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -7,6 +7,6 @@ IRBS_SERVER_URL=https://swc.iitg.ac.in/test/irbs
 GATELOG_WEBSOCKET_URL=wss://swc.iitg.ac.in/test/khokhaEntry/api/v1/ws
 GATELOG_SERVER_URL=https://swc.iitg.ac.in/test/khokhaEntry/api/v1
 MODERATION_SERVER_URL=https://swc.iitg.ac.in/onestopModerate
-EVENT_SERVER_URL=https://swc.iitg.ac.in/events
+EVENT_SERVER_URL=https://swc.iitg.ac.in/dev/onestop_events
 LIB_TOKEN_SOCKET_URL=wss://swc.iitg.ac.in/test/library/api
 LIB_TOKEN_BASE_URL=https://swc.iitg.ac.in/test/library/api

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,10 @@
                 android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme" />
 
+            <!-- <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>  -->
             <intent-filter>
                 <action android:name="FLUTTER_NOTIFICATION_CLICK" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/lib/models/event_scheduler/club_model.dart
+++ b/lib/models/event_scheduler/club_model.dart
@@ -1,0 +1,113 @@
+class ClubAchievement {
+  final String? title;
+  final String? year;
+
+  ClubAchievement({
+    this.title,
+    this.year,
+  });
+
+  factory ClubAchievement.fromJson(Map<String, dynamic> json) => ClubAchievement(
+        title: json['title'] as String?,
+        year: json['year']?.toString(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        if (title != null) 'title': title,
+        if (year != null) 'year': year,
+      };
+}
+
+class ClubTeamMember {
+  final String? name;
+  final String? position;
+  final String? number;
+  final String? email;
+
+  ClubTeamMember({
+    this.name,
+    this.position,
+    this.number,
+    this.email,
+  });
+
+  factory ClubTeamMember.fromJson(Map<String, dynamic> json) => ClubTeamMember(
+        name: json['name'] as String?,
+        position: json['position'] as String?,
+        number: json['number'] as String?,
+        email: json['email'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+        if (name != null) 'name': name,
+        if (position != null) 'position': position,
+        if (number != null) 'number': number,
+        if (email != null) 'email': email,
+      };
+}
+
+class ClubModel {
+  final String? id;
+  final String clubName;
+  final String? clubLogo;
+  final String? clubRoomLocation;
+  final String? boardName;
+  final String? clubDescription;
+  final List<ClubAchievement> achievements;
+  final String? howToJoin;
+  final List<ClubTeamMember> team;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  ClubModel({
+    this.id,
+    required this.clubName,
+    this.clubLogo,
+    this.clubRoomLocation,
+    this.boardName,
+    this.clubDescription,
+    this.achievements = const [],
+    this.howToJoin,
+    this.team = const [],
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory ClubModel.fromJson(Map<String, dynamic> json) => ClubModel(
+        id: json['_id'] as String? ?? json['club_id'] as String?,
+        clubName: (json['clubName'] as String?) ?? '',
+        clubLogo: json['clubLogo'] as String?,
+        clubRoomLocation: json['clubRoomLocation'] as String?,
+        boardName: json['boardName'] as String?,
+        clubDescription: json['clubDescription'] as String?,
+        achievements: (json['achievements'] as List<dynamic>?)
+                ?.map((e) => ClubAchievement.fromJson(e as Map<String, dynamic>))
+                .toList() ??
+            const [],
+        howToJoin: json['howToJoin'] as String?,
+        team: (json['team'] as List<dynamic>?)
+                ?.map((e) => ClubTeamMember.fromJson(e as Map<String, dynamic>))
+                .toList() ??
+            const [],
+        createdAt: json['createdAt'] != null
+            ? DateTime.tryParse(json['createdAt'] as String)
+            : null,
+        updatedAt: json['updatedAt'] != null
+            ? DateTime.tryParse(json['updatedAt'] as String)
+            : null,
+      );
+
+  Map<String, dynamic> toJson() => {
+        if (id != null) '_id': id,
+        'clubName': clubName,
+        if (clubLogo != null) 'clubLogo': clubLogo,
+        if (clubRoomLocation != null) 'clubRoomLocation': clubRoomLocation,
+        if (boardName != null) 'boardName': boardName,
+        if (clubDescription != null) 'clubDescription': clubDescription,
+        'achievements': achievements.map((e) => e.toJson()).toList(),
+        if (howToJoin != null) 'howToJoin': howToJoin,
+        'team': team.map((e) => e.toJson()).toList(),
+        if (createdAt != null) 'createdAt': createdAt!.toIso8601String(),
+        if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
+      };
+}

--- a/lib/models/event_scheduler/event_model.dart
+++ b/lib/models/event_scheduler/event_model.dart
@@ -1,133 +1,331 @@
 import 'dart:convert';
 
+class EventGuest {
+  final String? name;
+  final List<String> socials;
+  final String? position;
+  final String? photo;
+
+  EventGuest({
+    this.name,
+    this.socials = const [],
+    this.position,
+    this.photo,
+  });
+
+  factory EventGuest.fromJson(Map<String, dynamic> json) => EventGuest(
+        name: json['name'] as String?,
+        socials: (json['socials'] as List<dynamic>?)
+                ?.map((e) => e.toString())
+                .toList() ??
+            const [],
+        position: json['position'] as String?,
+        photo: json['photo'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+        if (name != null) 'name': name,
+        'socials': socials,
+        if (position != null) 'position': position,
+        if (photo != null) 'photo': photo,
+      };
+}
+
+class EventPOC {
+  final String? name;
+  final String? position;
+  final String? number;
+  final String? email;
+
+  EventPOC({
+    this.name,
+    this.position,
+    this.number,
+    this.email,
+  });
+
+  factory EventPOC.fromJson(Map<String, dynamic> json) => EventPOC(
+        name: json['name'] as String?,
+        position: json['position'] as String?,
+        number: json['number'] as String?,
+        email: json['email'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+        if (name != null) 'name': name,
+        if (position != null) 'position': position,
+        if (number != null) 'number': number,
+        if (email != null) 'email': email,
+      };
+}
+
+class EventStats {
+  final int interested;
+  final int going;
+
+  EventStats({
+    this.interested = 0,
+    this.going = 0,
+  });
+
+  factory EventStats.fromJson(Map<String, dynamic> json) => EventStats(
+        interested: (json['interested'] as num?)?.toInt() ?? 0,
+        going: (json['going'] as num?)?.toInt() ?? 0,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'interested': interested,
+        'going': going,
+      };
+}
+
+class EventUserStatus {
+  final bool isInterested;
+  final bool isRegistered;
+
+  EventUserStatus({
+    this.isInterested = false,
+    this.isRegistered = false,
+  });
+
+  factory EventUserStatus.fromJson(Map<String, dynamic> json) => EventUserStatus(
+        isInterested: (json['isInterested'] as bool?) ?? false,
+        isRegistered: (json['isRegistered'] as bool?) ?? false,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'isInterested': isInterested,
+        'isRegistered': isRegistered,
+      };
+}
+
 class EventModel {
-  String id;
-  String title;
-  String? imageUrl;
-  String? compressedImageUrl;
-  String description;
-  String clubOrg;
-  String board;
-  DateTime startDateTime;
-  DateTime endDateTime;
-  String venue;
-  List<String> categories;
-  int v;
+  final String id;
+  final String clubId;
+  final String name;
+  final String status;
+  final DateTime startTime;
+  final DateTime endTime;
+  final DateTime date;
+  final String? location;
+  final List<String> tags;
+  final String? eventBanner;
+  final List<EventGuest> guest;
+  final String? whoShouldAttend;
+  final String? description;
+  final int registrants;
+  final int likes;
+  final List<String> additionalLinks;
+  final List<String> feedback;
+  final List<EventPOC> poc;
+  final String? clubName;
+  final EventStats? stats;
+  final EventUserStatus? userStatus;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final int? v;
 
   EventModel({
     required this.id,
-    required this.title,
-    this.imageUrl,
-    this.compressedImageUrl,
-    required this.description,
-    required this.clubOrg,
-    required this.board,
-    required this.startDateTime,
-    required this.endDateTime,
-    required this.venue,
-    required this.categories,
-    required this.v,
+    required this.clubId,
+    required this.name,
+    this.status = 'DRAFT',
+    required this.startTime,
+    required this.endTime,
+    required this.date,
+    this.location,
+    this.tags = const [],
+    this.eventBanner,
+    this.guest = const [],
+    this.whoShouldAttend,
+    this.description,
+    this.registrants = 0,
+    this.likes = 0,
+    this.additionalLinks = const [],
+    this.feedback = const [],
+    this.poc = const [],
+    this.clubName,
+    this.stats,
+    this.userStatus,
+    this.createdAt,
+    this.updatedAt,
+    this.v,
   });
+
+  // Backward-compatibility getters
+  String get title => name;
+  String? get imageUrl => eventBanner;
+  String? get compressedImageUrl => eventBanner;
+  String? get venue => location;
+  DateTime get startDateTime => startTime;
+  DateTime get endDateTime => endTime;
+  String get clubOrg => clubName ?? '';
+  String get board => tags.isNotEmpty ? tags.first : '';
+  List<String> get categories => tags;
 
   EventModel copyWith({
     String? id,
-    String? title,
-    String? imageUrl,
-    String? compressedImageUrl,
+    String? clubId,
+    String? name,
+    String? status,
+    DateTime? startTime,
+    DateTime? endTime,
+    DateTime? date,
+    String? location,
+    List<String>? tags,
+    String? eventBanner,
+    List<EventGuest>? guest,
+    String? whoShouldAttend,
     String? description,
-    String? clubOrg,
-    String? board,
-    DateTime? startDateTime,
-    DateTime? endDateTime,
-    String? venue,
-    List<String>? categories,
+    int? registrants,
+    int? likes,
+    List<String>? additionalLinks,
+    List<String>? feedback,
+    List<EventPOC>? poc,
+    String? clubName,
+    EventStats? stats,
+    EventUserStatus? userStatus,
+    DateTime? createdAt,
+    DateTime? updatedAt,
     int? v,
   }) =>
       EventModel(
         id: id ?? this.id,
-        title: title ?? this.title,
-        imageUrl: imageUrl ?? this.imageUrl,
-        compressedImageUrl: compressedImageUrl ?? this.compressedImageUrl,
+        clubId: clubId ?? this.clubId,
+        name: name ?? this.name,
+        status: status ?? this.status,
+        startTime: startTime ?? this.startTime,
+        endTime: endTime ?? this.endTime,
+        date: date ?? this.date,
+        location: location ?? this.location,
+        tags: tags ?? this.tags,
+        eventBanner: eventBanner ?? this.eventBanner,
+        guest: guest ?? this.guest,
+        whoShouldAttend: whoShouldAttend ?? this.whoShouldAttend,
         description: description ?? this.description,
-        clubOrg: clubOrg ?? this.clubOrg,
-        board: board ?? this.board,
-        startDateTime: startDateTime ?? this.startDateTime,
-        endDateTime: endDateTime ?? this.endDateTime,
-        venue: venue ?? this.venue,
-        categories: categories ?? this.categories,
+        registrants: registrants ?? this.registrants,
+        likes: likes ?? this.likes,
+        additionalLinks: additionalLinks ?? this.additionalLinks,
+        feedback: feedback ?? this.feedback,
+        poc: poc ?? this.poc,
+        clubName: clubName ?? this.clubName,
+        stats: stats ?? this.stats,
+        userStatus: userStatus ?? this.userStatus,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt,
         v: v ?? this.v,
       );
 
   factory EventModel.fromRawJson(String str) =>
-      EventModel.fromJson(json.decode(str));
+      EventModel.fromJson(json.decode(str) as Map<String, dynamic>);
 
   String toRawJson() => json.encode(toJson());
 
-  factory EventModel.fromJson(Map<String, dynamic> json) => EventModel(
-        id: json["_id"],
-        title: json["title"],
-        imageUrl: json["imageURL"],
-        compressedImageUrl: json["compressedImageURL"],
-        description: json["description"],
-        clubOrg: json["club_org"],
-        board: json["board"],
-        startDateTime: DateTime.parse(json["startDateTime"]),
-        endDateTime: DateTime.parse(json["endDateTime"]),
-        venue: json["venue"],
-        categories: List<String>.from(json["categories"].map((x) => x)),
-        v: json["__v"],
-      );
+  factory EventModel.fromJson(Map<String, dynamic> json) {
+    DateTime parseDateTime(dynamic value) {
+      if (value is DateTime) return value;
+      if (value is String) return DateTime.tryParse(value) ?? DateTime.now();
+      return DateTime.now();
+    }
+
+    final clubIdVal = json['club_id'] is Map
+        ? (json['club_id']['_id'] as String? ?? '')
+        : (json['club_id'] as String? ?? '');
+
+    final tagsList = (json['Tags'] as List<dynamic>?) ??
+        (json['tags'] as List<dynamic>?) ??
+        (json['categories'] as List<dynamic>?);
+
+    final guestList = (json['guest'] as List<dynamic>?) ??
+        (json['guests'] as List<dynamic>?);
+
+    final pocList = (json['POC'] as List<dynamic>?) ??
+        (json['poc'] as List<dynamic>?);
+
+    final additionalLinksList = (json['additionalLinks'] as List<dynamic>?);
+    final feedbackList = (json['Feedback'] as List<dynamic>?) ??
+        (json['feedback'] as List<dynamic>?);
+
+    return EventModel(
+      id: (json['_id'] as String?) ?? (json['event_id'] as String?) ?? '',
+      clubId: clubIdVal,
+      name: (json['Name'] as String?) ??
+          (json['name'] as String?) ??
+          (json['title'] as String?) ??
+          '',
+      status: (json['status'] as String?) ?? 'DRAFT',
+      startTime: parseDateTime(json['startTime'] ?? json['startDateTime']),
+      endTime: parseDateTime(json['endTime'] ?? json['endDateTime']),
+      date: parseDateTime(json['Date'] ?? json['date'] ?? json['startTime'] ?? json['startDateTime']),
+      location: (json['Location'] as String?) ??
+          (json['location'] as String?) ??
+          (json['venue'] as String?),
+      tags: tagsList?.map((e) => e.toString()).toList() ?? const [],
+      eventBanner: (json['eventBanner'] as String?) ??
+          (json['imageURL'] as String?) ??
+          (json['compressedImageURL'] as String?),
+      guest: guestList
+              ?.map((e) => EventGuest.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      whoShouldAttend: (json['whoShouldAttend'] as String?),
+      description: (json['Description'] as String?) ??
+          (json['description'] as String?),
+      registrants: (json['Registrants'] as num?)?.toInt() ?? 0,
+      likes: (json['Likes'] as num?)?.toInt() ?? 0,
+      additionalLinks: additionalLinksList
+              ?.map((e) => e.toString())
+              .toList() ??
+          const [],
+      feedback: feedbackList?.map((e) => e.toString()).toList() ?? const [],
+      poc: pocList
+              ?.map((e) => EventPOC.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      clubName: (json['clubName'] as String?) ??
+          (json['club_org'] as String?) ??
+          (json['club_id'] is Map ? json['club_id']['clubName'] as String? : null),
+      stats: json['stats'] != null && json['stats'] is Map
+          ? EventStats.fromJson(json['stats'] as Map<String, dynamic>)
+          : null,
+      userStatus: json['userStatus'] != null && json['userStatus'] is Map
+          ? EventUserStatus.fromJson(
+              json['userStatus'] as Map<String, dynamic>)
+          : null,
+      createdAt: json['createdAt'] != null
+          ? DateTime.tryParse(json['createdAt'] as String)
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.tryParse(json['updatedAt'] as String)
+          : null,
+      v: (json['__v'] as num?)?.toInt(),
+    );
+  }
 
   Map<String, dynamic> toJson() => {
-        "_id": id,
-        "title": title,
-        "imageURL": imageUrl,
-        "compressedImageURL": compressedImageUrl,
-        "description": description,
-        "club_org": clubOrg,
-        "board": board,
-        "startDateTime": startDateTime.toIso8601String(),
-        "endDateTime": endDateTime.toIso8601String(),
-        "venue": venue,
-        "categories": List<dynamic>.from(categories.map((x) => x)),
-        "__v": v,
+        '_id': id,
+        'club_id': clubId,
+        'Name': name,
+        'status': status,
+        'startTime': startTime.toIso8601String(),
+        'endTime': endTime.toIso8601String(),
+        'Date': date.toIso8601String(),
+        if (location != null) 'Location': location,
+        'Tags': tags,
+        if (eventBanner != null) 'eventBanner': eventBanner,
+        'guest': guest.map((e) => e.toJson()).toList(),
+        if (whoShouldAttend != null) 'whoShouldAttend': whoShouldAttend,
+        if (description != null) 'Description': description,
+        'Registrants': registrants,
+        'Likes': likes,
+        'additionalLinks': additionalLinks,
+        'Feedback': feedback,
+        'POC': poc.map((e) => e.toJson()).toList(),
+        if (clubName != null) 'clubName': clubName,
+        if (stats != null) 'stats': stats!.toJson(),
+        if (userStatus != null) 'userStatus': userStatus!.toJson(),
+        if (createdAt != null) 'createdAt': createdAt!.toIso8601String(),
+        if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
+        if (v != null) '__v': v,
       };
 }
-
-
-/*
-import 'package:json_annotation/json_annotation.dart';
-
-part 'event_model.g.dart';
-
-@JsonSerializable(explicitToJson: true)
-class EventModel {
-  //@JsonKey(name: '_id')
-  final String id;
-  final String title;
-  final String description;
-  final String imageURL;
-  final String compressedImageURL;
-  final DateTime date;
-  final String club_org;
-  final String venue;
-  final String contactNumber;
-
-  const EventModel({
-    required this.id,
-    required this.title,
-    required this.description,
-    required this.imageURL,
-    required this.compressedImageURL,
-    required this.date,
-    required this.club_org,
-    required this.venue,
-    required this.contactNumber,
-  });
-
-  factory EventModel.fromJson(Map<String, dynamic> json) =>
-      _$EventModelFromJson(json);
-
-  Map<String, dynamic> toJson() => _$EventModelToJson(this);
-}
-*/

--- a/lib/models/event_scheduler/student_event_interaction_model.dart
+++ b/lib/models/event_scheduler/student_event_interaction_model.dart
@@ -1,0 +1,75 @@
+class EventFeedback {
+  final int? rating;
+  final String? comment;
+  final String? suggestions;
+
+  EventFeedback({
+    this.rating,
+    this.comment,
+    this.suggestions,
+  });
+
+  factory EventFeedback.fromJson(Map<String, dynamic> json) => EventFeedback(
+        rating: json['rating'] as int?,
+        comment: json['comment'] as String?,
+        suggestions: json['suggestions'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+        if (rating != null) 'rating': rating,
+        if (comment != null) 'comment': comment,
+        if (suggestions != null) 'suggestions': suggestions,
+      };
+}
+
+class StudentEventInteractionModel {
+  final String? id;
+  final String studentId;
+  final String eventId;
+  final bool like;
+  final EventFeedback? feedback;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  StudentEventInteractionModel({
+    this.id,
+    required this.studentId,
+    required this.eventId,
+    this.like = false,
+    this.feedback,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory StudentEventInteractionModel.fromJson(Map<String, dynamic> json) =>
+      StudentEventInteractionModel(
+        id: json['_id'] as String?,
+        studentId: json['student_id'] is Map
+            ? (json['student_id']['_id'] as String? ?? '')
+            : (json['student_id'] as String? ?? ''),
+        eventId: json['event_id'] is Map
+            ? (json['event_id']['_id'] as String? ?? '')
+            : (json['event_id'] as String? ?? ''),
+        like: (json['like'] as bool?) ?? false,
+        feedback: json['feedback'] != null && json['feedback'] is Map
+            ? EventFeedback.fromJson(
+                json['feedback'] as Map<String, dynamic>)
+            : null,
+        createdAt: json['createdAt'] != null
+            ? DateTime.tryParse(json['createdAt'] as String)
+            : null,
+        updatedAt: json['updatedAt'] != null
+            ? DateTime.tryParse(json['updatedAt'] as String)
+            : null,
+      );
+
+  Map<String, dynamic> toJson() => {
+        if (id != null) '_id': id,
+        'student_id': studentId,
+        'event_id': eventId,
+        'like': like,
+        if (feedback != null) 'feedback': feedback!.toJson(),
+        if (createdAt != null) 'createdAt': createdAt!.toIso8601String(),
+        if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
+      };
+}

--- a/lib/models/event_scheduler/student_model.dart
+++ b/lib/models/event_scheduler/student_model.dart
@@ -1,0 +1,47 @@
+class StudentModel {
+  final String? id;
+  final String? name;
+  final String email;
+  final String? branch;
+  final String? year;
+  final String rollNumber;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  StudentModel({
+    this.id,
+    this.name,
+    required this.email,
+    this.branch,
+    this.year,
+    required this.rollNumber,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory StudentModel.fromJson(Map<String, dynamic> json) => StudentModel(
+        id: json['_id'] as String?,
+        name: json['name'] as String?,
+        email: (json['email'] as String?) ?? '',
+        branch: json['branch'] as String?,
+        year: json['year']?.toString(),
+        rollNumber: (json['rollNumber'] as String?) ?? '',
+        createdAt: json['createdAt'] != null
+            ? DateTime.tryParse(json['createdAt'] as String)
+            : null,
+        updatedAt: json['updatedAt'] != null
+            ? DateTime.tryParse(json['updatedAt'] as String)
+            : null,
+      );
+
+  Map<String, dynamic> toJson() => {
+        if (id != null) '_id': id,
+        if (name != null) 'name': name,
+        'email': email,
+        if (branch != null) 'branch': branch,
+        if (year != null) 'year': year,
+        'rollNumber': rollNumber,
+        if (createdAt != null) 'createdAt': createdAt!.toIso8601String(),
+        if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
+      };
+}

--- a/lib/pages/events/clubs_fest_page.dart
+++ b/lib/pages/events/clubs_fest_page.dart
@@ -1,56 +1,368 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
+import 'package:onestop_dev/models/event_scheduler/club_model.dart';
+import 'package:onestop_dev/pages/events/widgets/poc_modal.dart';
+import 'package:onestop_dev/repository/events_api_repository.dart';
 import 'package:onestop_ui/index.dart';
 
-/// Placeholder page for the Clubs/Fest section.
-///
-/// This will be replaced with actual content once the design and
-/// API integration are ready.
-class ClubsFestPage extends StatelessWidget {
+/// Page for the Clubs & Fests section, connected to backend APIs.
+class ClubsFestPage extends StatefulWidget {
   const ClubsFestPage({super.key});
+
+  @override
+  State<ClubsFestPage> createState() => _ClubsFestPageState();
+}
+
+class _ClubsFestPageState extends State<ClubsFestPage> {
+  final EventsAPIRepository _apiRepo = EventsAPIRepository();
+
+  final List<String> _categories = [
+    'All',
+    'Technical',
+    'Cultural',
+    'Sports',
+    'Welfare',
+    'SWC',
+    'Academic',
+  ];
+
+  String _selectedCategory = 'All';
+  List<ClubModel> _clubs = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchClubs();
+  }
+
+  Future<void> _fetchClubs() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    final categoryParam = _selectedCategory == 'All' ? null : _selectedCategory;
+    final clubs = await _apiRepo.getAllClubs(category: categoryParam);
+
+    if (mounted) {
+      setState(() {
+        _clubs = clubs;
+        _isLoading = false;
+      });
+    }
+  }
+
+  void _showClubDetailsModal(ClubModel club) async {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) {
+        return DraggableScrollableSheet(
+          initialChildSize: 0.75,
+          minChildSize: 0.4,
+          maxChildSize: 0.9,
+          builder: (context, scrollController) {
+            return FutureBuilder<ClubModel?>(
+              future: club.id != null ? _apiRepo.getClubDetails(club.id!) : Future.value(club),
+              builder: (context, snapshot) {
+                final detailedClub = snapshot.data ?? club;
+                return Container(
+                  decoration: BoxDecoration(
+                    color: OColor.white,
+                    borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+                  ),
+                  padding: const EdgeInsets.all(OSpacing.m),
+                  child: ListView(
+                    controller: scrollController,
+                    children: [
+                      Center(
+                        child: Container(
+                          width: 40,
+                          height: 4,
+                          decoration: BoxDecoration(
+                            color: OColor.gray300,
+                            borderRadius: BorderRadius.circular(2),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: OSpacing.m),
+                      Row(
+                        children: [
+                          Container(
+                            width: 56,
+                            height: 56,
+                            decoration: BoxDecoration(
+                              color: OColor.blue100,
+                              shape: BoxShape.circle,
+                            ),
+                            child: detailedClub.clubLogo != null && detailedClub.clubLogo!.isNotEmpty
+                                ? ClipOval(
+                                    child: Image.network(
+                                      detailedClub.clubLogo!,
+                                      fit: BoxFit.cover,
+                                      errorBuilder: (_, _, _) => Icon(
+                                        FluentIcons.people_community_24_regular,
+                                        color: OColor.blue600,
+                                      ),
+                                    ),
+                                  )
+                                : Icon(
+                                    FluentIcons.people_community_24_regular,
+                                    color: OColor.blue600,
+                                  ),
+                          ),
+                          const SizedBox(width: OSpacing.m),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                OText(
+                                  text: detailedClub.clubName,
+                                  style: OTextStyle.headingMedium.copyWith(color: OColor.gray800),
+                                ),
+                                if (detailedClub.boardName != null)
+                                  OText(
+                                    text: detailedClub.boardName!,
+                                    style: OTextStyle.bodySmall.copyWith(color: OColor.gray600),
+                                  ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: OSpacing.l),
+                      if (detailedClub.clubDescription != null && detailedClub.clubDescription!.isNotEmpty) ...[
+                        OText(
+                          text: 'About',
+                          style: OTextStyle.labelMedium.copyWith(color: OColor.gray600),
+                        ),
+                        const SizedBox(height: OSpacing.xxs),
+                        OText(
+                          text: detailedClub.clubDescription!,
+                          style: OTextStyle.bodyMedium.copyWith(color: OColor.gray800),
+                        ),
+                        const SizedBox(height: OSpacing.l),
+                      ],
+                      if (detailedClub.clubRoomLocation != null && detailedClub.clubRoomLocation!.isNotEmpty) ...[
+                        Row(
+                          children: [
+                            Icon(FluentIcons.location_16_regular, size: 16, color: OColor.gray600),
+                            const SizedBox(width: OSpacing.xs),
+                            Expanded(
+                              child: OText(
+                                text: detailedClub.clubRoomLocation!,
+                                style: OTextStyle.bodySmall.copyWith(color: OColor.gray600),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: OSpacing.l),
+                      ],
+                      if (detailedClub.team.isNotEmpty) ...[
+                        OText(
+                          text: 'Team & POCs',
+                          style: OTextStyle.labelMedium.copyWith(color: OColor.gray600),
+                        ),
+                        const SizedBox(height: OSpacing.s),
+                        ...detailedClub.team.map((member) {
+                          return ListTile(
+                            contentPadding: EdgeInsets.zero,
+                            leading: CircleAvatar(
+                              backgroundColor: OColor.blue100,
+                              child: Icon(FluentIcons.person_24_regular, color: OColor.blue500),
+                            ),
+                            title: OText(text: member.name ?? 'Member', style: OTextStyle.labelMedium),
+                            subtitle: OText(text: member.position ?? 'Position', style: OTextStyle.bodySmall),
+                            trailing: member.number != null
+                                ? IconButton(
+                                    icon: Icon(FluentIcons.call_24_regular, color: OColor.green600),
+                                    onPressed: () {
+                                      showPOCModal(
+                                        context,
+                                        name: member.name ?? '',
+                                        subtitle: member.position ?? '',
+                                        number: member.number,
+                                        email: member.email,
+                                      );
+                                    },
+                                  )
+                                : null,
+                          );
+                        }),
+                      ],
+                    ],
+                  ),
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: OColor.gray100,
       body: SafeArea(
-        child: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Container(
-                width: 80,
-                height: 80,
-                decoration: BoxDecoration(
-                  color: OColor.green100,
-                  borderRadius: BorderRadius.circular(OCornerRadius.l),
-                ),
-                child: Icon(
-                  FluentIcons.people_community_24_regular,
-                  size: 40,
-                  color: OColor.green600,
-                ),
-              ),
-              const SizedBox(height: OSpacing.m),
-              OText(
-                text: 'Clubs & Fests',
-                style: OTextStyle.headingLarge.copyWith(
-                  color: OColor.gray800,
-                ),
-              ),
-              const SizedBox(height: OSpacing.s),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: OSpacing.xl),
-                child: OText(
-                  text: 'Explore clubs and fests happening around campus. Coming soon!',
-                  style: OTextStyle.bodyMedium.copyWith(
-                    color: OColor.gray600,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Top title
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: OSpacing.m).copyWith(top: OSpacing.m),
+              child: Row(
+                children: [
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: OColor.green100,
+                      borderRadius: BorderRadius.circular(OCornerRadius.m),
+                    ),
+                    child: Icon(
+                      FluentIcons.people_community_24_regular,
+                      color: OColor.green600,
+                    ),
                   ),
-                  textAlign: TextAlign.center,
-                ),
+                  const SizedBox(width: OSpacing.m),
+                  OText(
+                    text: 'Clubs & Fests',
+                    style: OTextStyle.headingLarge.copyWith(color: OColor.gray800),
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+            const SizedBox(height: OSpacing.m),
+
+            // Board Categories Bar
+            SizedBox(
+              height: 38,
+              child: ListView.separated(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+                itemCount: _categories.length,
+                separatorBuilder: (_, _) => const SizedBox(width: OSpacing.xs),
+                itemBuilder: (context, index) {
+                  final cat = _categories[index];
+                  final isSelected = cat == _selectedCategory;
+                  return GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        _selectedCategory = cat;
+                      });
+                      _fetchClubs();
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+                      decoration: BoxDecoration(
+                        color: isSelected ? OColor.green600 : OColor.white,
+                        borderRadius: BorderRadius.circular(OCornerRadius.l),
+                        border: Border.all(
+                          color: isSelected ? OColor.green600 : OColor.gray300,
+                        ),
+                      ),
+                      child: Center(
+                        child: OText(
+                          text: cat,
+                          style: OTextStyle.labelSmall.copyWith(
+                            color: isSelected ? OColor.white : OColor.gray700,
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: OSpacing.m),
+
+            // Clubs list / grid
+            Expanded(
+              child: _isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : _clubs.isEmpty
+                      ? Center(
+                          child: OText(
+                            text: 'No clubs found for $_selectedCategory',
+                            style: OTextStyle.bodyMedium.copyWith(color: OColor.gray600),
+                          ),
+                        )
+                      : RefreshIndicator(
+                          onRefresh: _fetchClubs,
+                          child: ListView.separated(
+                            padding: const EdgeInsets.all(OSpacing.m),
+                            itemCount: _clubs.length,
+                            separatorBuilder: (_, _) => const SizedBox(height: OSpacing.s),
+                            itemBuilder: (context, index) {
+                              final club = _clubs[index];
+                              return GestureDetector(
+                                onTap: () => _showClubDetailsModal(club),
+                                child: Container(
+                                  padding: const EdgeInsets.all(OSpacing.m),
+                                  decoration: BoxDecoration(
+                                    color: OColor.white,
+                                    borderRadius: BorderRadius.circular(OCornerRadius.m),
+                                    border: Border.all(color: OColor.gray200),
+                                  ),
+                                  child: Row(
+                                    children: [
+                                      Container(
+                                        width: 48,
+                                        height: 48,
+                                        decoration: BoxDecoration(
+                                          color: OColor.green100,
+                                          shape: BoxShape.circle,
+                                        ),
+                                        child: club.clubLogo != null && club.clubLogo!.isNotEmpty
+                                            ? ClipOval(
+                                                child: Image.network(
+                                                  club.clubLogo!,
+                                                  fit: BoxFit.cover,
+                                                  errorBuilder: (_, _, _) => Icon(
+                                                    FluentIcons.people_community_24_regular,
+                                                    color: OColor.green600,
+                                                  ),
+                                                ),
+                                              )
+                                            : Icon(
+                                                FluentIcons.people_community_24_regular,
+                                                color: OColor.green600,
+                                              ),
+                                      ),
+                                      const SizedBox(width: OSpacing.m),
+                                      Expanded(
+                                        child: Column(
+                                          crossAxisAlignment: CrossAxisAlignment.start,
+                                          children: [
+                                            OText(
+                                              text: club.clubName,
+                                              style: OTextStyle.labelLarge.copyWith(color: OColor.gray800),
+                                            ),
+                                            if (club.boardName != null && club.boardName!.isNotEmpty)
+                                              OText(
+                                                text: club.boardName!,
+                                                style: OTextStyle.bodySmall.copyWith(color: OColor.gray600),
+                                              ),
+                                          ],
+                                        ),
+                                      ),
+                                      Icon(
+                                        FluentIcons.chevron_right_24_regular,
+                                        size: 20,
+                                        color: OColor.gray400,
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/events/events_home_page.dart
+++ b/lib/pages/events/events_home_page.dart
@@ -1,145 +1,766 @@
+import 'dart:async';
+import 'dart:developer';
+
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
+import 'package:fuzzy/fuzzy.dart';
 import 'package:intl/intl.dart';
+import 'package:onestop_dev/functions/utility/show_snackbar.dart';
 import 'package:onestop_dev/models/event_scheduler/event_model.dart';
+import 'package:onestop_dev/pages/events/clubs_fest_page.dart';
 import 'package:onestop_dev/pages/events/widgets/event_listing_large_card.dart';
 import 'package:onestop_dev/pages/events/widgets/event_listing_medium_card.dart';
 import 'package:onestop_dev/pages/events/widgets/event_listing_small_card.dart';
+import 'package:onestop_dev/pages/events/widgets/event_popup.dart';
 import 'package:onestop_dev/pages/events/widgets/event_search_bar.dart';
 import 'package:onestop_dev/pages/events/widgets/event_toggle_tiles.dart';
 import 'package:onestop_dev/pages/events/widgets/events_compact_card.dart';
+import 'package:onestop_dev/pages/events/widgets/events_home_shimmer.dart';
 import 'package:onestop_dev/pages/events/widgets/section_header.dart';
-import 'package:onestop_dev/pages/events/widgets/event_popup.dart';
+import 'package:onestop_dev/pages/events_feed/events_appbar.dart';
+import 'package:onestop_dev/repository/events_api_repository.dart';
+import 'package:onestop_dev/stores/login_store.dart';
 import 'package:onestop_ui/index.dart';
 
-/// The new Events Homepage screen, matching the Figma design.
-///
-/// A scrollable page composed of:
-/// - Header (title + date + profile avatar)
-/// - Search bar
-/// - Toggle tiles (All Events / Saved Events)
-/// - Happening Today (horizontal scroll of small cards)
-/// - Trending Events (horizontal scroll of medium cards)
-/// - Your Interests (vertical list of large cards)
-/// - Recently Attended (horizontal scroll of compact cards)
-/// - Explore (vertical list of large cards)
-class EventsHomePage extends StatelessWidget {
+/// The Events Homepage screen with live fuzzy search and backend API integration.
+class EventsHomePage extends StatefulWidget {
+  static const id = "/events/home";
+
   const EventsHomePage({super.key});
 
   @override
+  State<EventsHomePage> createState() => _EventsHomePageState();
+}
+
+class _EventsHomePageState extends State<EventsHomePage> {
+  final EventsAPIRepository _apiRepo = EventsAPIRepository();
+
+  List<EventModel> _todayEvents = [];
+  List<EventModel> _trendingEvents = [];
+  List<EventModel> _interestsEvents = [];
+  List<EventModel> _exploreEvents = [];
+  List<EventModel> _likedEvents = [];
+  final Set<String> _initialLikedEventIds = {};
+  final Set<String> _initialGoingEventIds = {};
+
+  // Search & Fuzzy Indexing
+  final TextEditingController _searchController = TextEditingController();
+  final FocusNode _searchFocusNode = FocusNode();
+  String _searchQuery = '';
+  List<EventModel> _searchResults = [];
+  bool _isSearching = false;
+  Timer? _debounceTimer;
+  Fuzzy<EventModel>? _fuzzyEngine;
+  List<EventModel> _allIndexedEvents = [];
+
+  bool _isLoading = true;
+  bool _hasError = false;
+  int _allEventsCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAllHomeData();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _searchFocusNode.dispose();
+    _debounceTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _loadAllHomeData() async {
+    setState(() {
+      _isLoading = true;
+      _hasError = false;
+    });
+
+    try {
+      final rollNo = LoginStore.userData['rollNo'] ?? '';
+      final email = LoginStore.userData['outlookEmail'] ?? '';
+
+      final results = await Future.wait([
+        _apiRepo.getAllEvents(feedType: 'TODAY'),
+        _apiRepo.getAllEvents(feedType: 'TRENDING'),
+        _apiRepo.getAllEvents(feedType: 'INTERESTS'),
+        _apiRepo.getAllEvents(limit: 10),
+        if (rollNo.isNotEmpty || email.isNotEmpty)
+          _apiRepo.getUserLikedEvents(rollNo: rollNo, email: email)
+        else
+          Future.value(<EventModel>[]),
+      ]);
+
+      if (mounted) {
+        setState(() {
+          _todayEvents = results[0];
+          _trendingEvents = results[1];
+          _interestsEvents = results[2];
+          _exploreEvents = results[3];
+          _likedEvents = results[4];
+          _allEventsCount =
+              _exploreEvents.length +
+              _todayEvents.length +
+              _trendingEvents.length;
+          _isLoading = false;
+          _hasError = false;
+
+          // Snapshot initial liked & going IDs to avoid double counting baseline
+          _initialLikedEventIds.clear();
+          for (var e in _likedEvents) {
+            _initialLikedEventIds.add(e.id);
+          }
+          _initialGoingEventIds.clear();
+
+          // Index all events for fast multi-field fuzzy search with unique deterministic key
+          final Map<String, EventModel> uniqueEvents = {};
+          for (var list in [
+            _todayEvents,
+            _trendingEvents,
+            _interestsEvents,
+            _exploreEvents,
+            _likedEvents,
+          ]) {
+            for (var e in list) {
+              final key =
+                  e.id.isNotEmpty
+                      ? e.id
+                      : '${e.clubId}_${e.name}_${e.startDateTime.millisecondsSinceEpoch}';
+              uniqueEvents[key] = e;
+              if (e.userStatus?.isInterested == true) {
+                _initialLikedEventIds.add(e.id);
+              }
+              if (e.userStatus?.isRegistered == true) {
+                _initialGoingEventIds.add(e.id);
+              }
+            }
+          }
+          _allIndexedEvents = uniqueEvents.values.toList();
+          _rebuildFuzzyIndex();
+        });
+      }
+    } catch (e) {
+      log('Error loading home data: $e');
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+          _hasError = _allIndexedEvents.isEmpty;
+        });
+      }
+    }
+  }
+
+  /// Builds a strict, narrow-scoped weighted fuzzy search engine
+  void _rebuildFuzzyIndex() {
+    if (_allIndexedEvents.isEmpty) return;
+    _fuzzyEngine = Fuzzy<EventModel>(
+      _allIndexedEvents,
+      options: FuzzyOptions(
+        keys: [
+          WeightedKey(
+            name: 'name',
+            getter: (EventModel e) => e.name,
+            weight: 0.55,
+          ),
+          WeightedKey(
+            name: 'clubName',
+            getter: (EventModel e) => e.clubOrg,
+            weight: 0.25,
+          ),
+          WeightedKey(
+            name: 'tags',
+            getter: (EventModel e) => e.tags.join(' '),
+            weight: 0.15,
+          ),
+          WeightedKey(
+            name: 'description',
+            getter: (EventModel e) => e.description ?? '',
+            weight: 0.05,
+          ),
+        ],
+        threshold:
+            0.20, // Stricter threshold (0.0 is exact, 0.20 eliminates false positives)
+        findAllMatches: false,
+        tokenize: true,
+      ),
+    );
+  }
+
+  /// Handles search query change with instant local fuzzy search + debounced backend fallback
+  void _onSearchChanged(String query) {
+    _debounceTimer?.cancel();
+    final trimmed = query.trim();
+
+    if (trimmed.isEmpty) {
+      setState(() {
+        _searchQuery = '';
+        _searchResults = [];
+        _isSearching = false;
+      });
+      return;
+    }
+
+    setState(() {
+      _searchQuery = trimmed;
+      _isSearching = true;
+    });
+
+    // 1. Instant local fuzzy search
+    _performLocalSearch(trimmed);
+
+    // 2. Debounced remote search (300ms) for newly indexed/remote events
+    _debounceTimer = Timer(const Duration(milliseconds: 300), () async {
+      await _performRemoteSearch(trimmed);
+    });
+  }
+
+  static final RegExp _whitespaceRegex = RegExp(r'\s+');
+
+  /// Optimized strict local search: prioritizes titles, clubs, tags, and word boundaries
+  void _performLocalSearch(String query) {
+    final lowerQuery = query.toLowerCase();
+    final Set<String> matchedIds = {};
+    final List<EventModel> results = [];
+
+    // Step 1: Strict Direct Matching (Title, Club, Tag Prefix/Match, Description Word Boundary)
+    for (final event in _allIndexedEvents) {
+      final nameWords = event.name.toLowerCase().split(_whitespaceRegex);
+      final nameMatch =
+          nameWords.any((w) => w.startsWith(lowerQuery)) ||
+          event.name.toLowerCase().contains(lowerQuery);
+
+      final clubWords = event.clubOrg.toLowerCase().split(_whitespaceRegex);
+      final clubMatch =
+          clubWords.any((w) => w.startsWith(lowerQuery)) ||
+          event.clubOrg.toLowerCase().contains(lowerQuery);
+
+      final tagsMatch = event.tags.any(
+        (t) =>
+            t.toLowerCase().startsWith(lowerQuery) ||
+            t.toLowerCase() == lowerQuery,
+      );
+
+      // Description only matched for queries >= 3 chars on whole words/prefixes
+      final descMatch =
+          query.length >= 3 &&
+          (event.description
+                  ?.toLowerCase()
+                  .split(_whitespaceRegex)
+                  .any((w) => w.startsWith(lowerQuery)) ??
+              false);
+
+      if (nameMatch || clubMatch || tagsMatch || descMatch) {
+        if (matchedIds.add(event.id)) {
+          results.add(event);
+        }
+      }
+    }
+
+    // Step 2: Strict Fuzzy search match (score <= 0.20)
+    if (_fuzzyEngine != null && query.length >= 2) {
+      final fuzzyMatches = _fuzzyEngine!.search(query);
+      for (final match in fuzzyMatches) {
+        if (match.score <= 0.20 && matchedIds.add(match.item.id)) {
+          results.add(match.item);
+        }
+      }
+    }
+
+    if (mounted && _searchQuery == query) {
+      setState(() {
+        _searchResults = results;
+        _isSearching = false;
+      });
+    }
+  }
+
+  /// Remote search query sent to backend API to supplement local cache
+  Future<void> _performRemoteSearch(String query) async {
+    try {
+      final remoteEvents = await _apiRepo.getAllEvents(search: query);
+      if (remoteEvents.isNotEmpty && mounted && _searchQuery == query) {
+        final Set<String> existingIds = _searchResults.map((e) => e.id).toSet();
+        final updated = List<EventModel>.from(_searchResults);
+
+        for (final re in remoteEvents) {
+          if (existingIds.add(re.id)) {
+            updated.add(re);
+            if (!_allIndexedEvents.any((e) => e.id == re.id)) {
+              _allIndexedEvents.add(re);
+            }
+          }
+        }
+
+        setState(() {
+          _searchResults = updated;
+          _isSearching = false;
+        });
+        _rebuildFuzzyIndex();
+      }
+    } catch (_) {}
+  }
+
+  Future<void> _handleToggleLike(EventModel event) async {
+    final rollNo =
+        LoginStore.userData['rollNo']?.toString() ??
+        LoginStore.userData['rollno']?.toString() ??
+        LoginStore.userData['rollNumber']?.toString() ??
+        'guest';
+    final email =
+        LoginStore.userData['outlookEmail']?.toString() ??
+        LoginStore.userData['email']?.toString() ??
+        'guest@iitg.ac.in';
+
+    final isCurrentlyLiked = _likedEvents.any((e) => e.id == event.id);
+    final targetState = !isCurrentlyLiked;
+
+    // Optimistic UI update
+    setState(() {
+      if (targetState) {
+        if (!_likedEvents.any((e) => e.id == event.id)) {
+          _likedEvents.add(event);
+        }
+      } else {
+        _likedEvents.removeWhere((e) => e.id == event.id);
+      }
+    });
+
+    try {
+      final res = await _apiRepo.toggleLikeEvent(
+        rollNo: rollNo,
+        email: email,
+        eventId: event.id,
+        like: targetState,
+      );
+
+      if (mounted) {
+        if (res != null) {
+          setState(() {
+            if (res.like) {
+              if (!_likedEvents.any((e) => e.id == event.id)) {
+                _likedEvents.add(event);
+              }
+            } else {
+              _likedEvents.removeWhere((e) => e.id == event.id);
+            }
+          });
+        }
+        showSnackBar(targetState ? "Marked as going!" : "Removed from going");
+      }
+    } catch (_) {
+      if (mounted) {
+        showSnackBar(targetState ? "Marked as going!" : "Removed from going");
+      }
+    }
+  }
+
+  Future<void> _openEventPopup(EventModel event) async {
+    final isCurrentlyGoing =
+        _likedEvents.any((e) => e.id == event.id) ||
+        (event.userStatus?.isRegistered ?? false);
+
+    await showEventPopup(
+      context,
+      event: event,
+      isInitiallyInterested: isCurrentlyGoing,
+      isInitiallyRegistered: event.userStatus?.isRegistered ?? false,
+      onStatusChanged: (isInterested, isRegistered) {
+        if (mounted) {
+          setState(() {
+            if (isInterested || isRegistered) {
+              if (!_likedEvents.any((e) => e.id == event.id)) {
+                _likedEvents.add(event);
+              }
+            } else {
+              _likedEvents.removeWhere((e) => e.id == event.id);
+            }
+          });
+        }
+      },
+    );
+
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  /// Computes the live interested count factoring in the current user's interaction
+  int _getEventInterestedCount(EventModel event) {
+    final baseCount = event.stats?.interested ?? event.likes;
+    final initiallyLiked = _initialLikedEventIds.contains(event.id);
+    final currentlyLiked = _likedEvents.any((e) => e.id == event.id);
+
+    if (currentlyLiked && !initiallyLiked) {
+      return baseCount + 1;
+    } else if (!currentlyLiked && initiallyLiked) {
+      return (baseCount > 0) ? baseCount - 1 : 0;
+    }
+    return baseCount;
+  }
+
+  /// Computes the live going count factoring in the current user's registration
+  int _getEventGoingCount(EventModel event) {
+    final baseCount = event.stats?.going ?? event.registrants;
+    final initiallyGoing = _initialGoingEventIds.contains(event.id);
+    final currentlyGoing =
+        _likedEvents.any((e) => e.id == event.id) ||
+        (event.userStatus?.isRegistered == true);
+
+    if (currentlyGoing && !initiallyGoing) {
+      return baseCount + 1;
+    } else if (!currentlyGoing && initiallyGoing) {
+      return (baseCount > 0) ? baseCount - 1 : 0;
+    }
+    return baseCount;
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final mockEvents = _generateMockEvents();
+    final isSearchingActive = _searchQuery.isNotEmpty;
 
     return Scaffold(
       backgroundColor: OColor.gray100,
       body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.only(bottom: 120),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Header
-              _buildHeader(context),
-              const SizedBox(height: OSpacing.m),
+        child: RefreshIndicator(
+          onRefresh: _loadAllHomeData,
+          color: OColor.green600,
+          child: SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.only(bottom: 120),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Header
+                _buildHeader(context),
+                const SizedBox(height: OSpacing.m),
 
-              // Search bar
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
-                child: EventSearchBar(
-                  placeholder: 'Placeholder Text',
-                  onTap: () {
-                    // TODO: Navigate to search
-                  },
+                // Live Interactive Search Bar
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+                  child: EventSearchBar(
+                    placeholder:
+                        'Search events by name, club, tags or description',
+                    controller: _searchController,
+                    focusNode: _searchFocusNode,
+                    isLoading: _isSearching,
+                    onChanged: _onSearchChanged,
+                    onClear: () => _onSearchChanged(''),
+                  ),
                 ),
-              ),
-              const SizedBox(height: OSpacing.s),
+                const SizedBox(height: OSpacing.s),
 
-              // Toggle tiles
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
-                child: EventToggleTiles(
-                  allEventsCount: 56,
-                  onAllEventsTap: () {
-                    // TODO: Navigate to all events
-                  },
-                  onSavedEventsTap: () {
-                    // TODO: Navigate to saved events
-                  },
-                ),
-              ),
-              const SizedBox(height: OSpacing.l),
+                // If user is searching, show search results section with Large Cards
+                if (isSearchingActive)
+                  _buildSearchResultsSection()
+                else ...[
+                  // Toggle tiles
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+                    child: EventToggleTiles(
+                      allEventsCount: _isLoading ? 0 : _allEventsCount,
+                      onAllEventsTap: () {
+                        // TODO: Deep-link directly to "All" category tab in EventsScreenWrapper or dedicated All Events screen
+                        Navigator.pushNamed(context, EventsScreenWrapper.id);
+                      },
+                      onSavedEventsTap: () {
+                        // TODO: Deep-link directly to "Saved" category tab (index 0) in EventsScreenWrapper or dedicated Saved Events screen
+                        Navigator.pushNamed(context, EventsScreenWrapper.id);
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: OSpacing.l),
 
-              // Happening Today
-              _buildHappeningTodaySection(mockEvents),
-              const SizedBox(height: OSpacing.l),
+                  if (_isLoading)
+                    const EventsHomeShimmer()
+                  else if (_hasError && _allIndexedEvents.isEmpty)
+                    _buildErrorState()
+                  else ...[
+                    // Happening Today
+                    if (_todayEvents.isNotEmpty) ...[
+                      _buildHappeningTodaySection(_todayEvents),
+                      const SizedBox(height: OSpacing.l),
+                    ],
 
-              // Trending Events
-              _buildTrendingEventsSection(mockEvents),
-              const SizedBox(height: OSpacing.l),
+                    // Trending Events
+                    if (_trendingEvents.isNotEmpty) ...[
+                      _buildTrendingEventsSection(_trendingEvents),
+                      const SizedBox(height: OSpacing.l),
+                    ],
 
-              // Your Interests
-              _buildYourInterestsSection(mockEvents),
-              const SizedBox(height: OSpacing.l),
+                    // Your Interests
+                    if (_interestsEvents.isNotEmpty) ...[
+                      _buildYourInterestsSection(_interestsEvents),
+                      const SizedBox(height: OSpacing.l),
+                    ],
 
-              // Recently Attended
-              _buildRecentlyAttendedSection(mockEvents),
-              const SizedBox(height: OSpacing.l),
+                    // Saved / Attended Events
+                    if (_likedEvents.isNotEmpty) ...[
+                      _buildRecentlyAttendedSection(_likedEvents),
+                      const SizedBox(height: OSpacing.l),
+                    ],
 
-              // Explore
-              _buildExploreSection(mockEvents),
-            ],
+                    // Explore
+                    _buildExploreSection(
+                      _exploreEvents.isNotEmpty
+                          ? _exploreEvents
+                          : _generateMockEvents(),
+                    ),
+                  ],
+                ],
+              ],
+            ),
           ),
         ),
       ),
     );
   }
 
-  /// Header: "Events" title + day/date + profile avatar
-  Widget _buildHeader(BuildContext context) {
-    final now = DateTime.now();
-    final dayName = DateFormat('EEEE').format(now);
-    final dayDate = DateFormat('d').format(now);
-    final daySuffix = _getDaySuffix(int.parse(dayDate));
-    final month = DateFormat('MMMM').format(now);
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: OSpacing.m)
-          .copyWith(top: OSpacing.m),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: TextBaseline.alphabetic,
-            children: [
-              OText(
-                text: 'Events',
-                style: OTextStyle.headingLarge.copyWith(
-                  color: OColor.gray800,
+  /// Error & offline state with retry button
+  Widget _buildErrorState() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: 48,
+          horizontal: OSpacing.m,
+        ),
+        child: Column(
+          children: [
+            Icon(
+              FluentIcons.error_circle_24_regular,
+              size: 48,
+              color: OColor.gray400,
+            ),
+            const SizedBox(height: OSpacing.s),
+            OText(
+              text: 'Unable to load events',
+              style: OTextStyle.bodyMedium.copyWith(color: OColor.gray700),
+            ),
+            const SizedBox(height: OSpacing.xxs),
+            OText(
+              text: 'Please check your internet connection and try again.',
+              style: OTextStyle.bodySmall.copyWith(color: OColor.gray500),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: OSpacing.m),
+            GestureDetector(
+              onTap: _loadAllHomeData,
+              behavior: HitTestBehavior.opaque,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: OSpacing.m,
+                  vertical: OSpacing.s,
+                ),
+                decoration: BoxDecoration(
+                  color: OColor.green600,
+                  borderRadius: BorderRadius.circular(OCornerRadius.m),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      FluentIcons.arrow_clockwise_24_regular,
+                      size: 16,
+                      color: OColor.white,
+                    ),
+                    const SizedBox(width: OSpacing.xs),
+                    OText(
+                      text: 'Retry',
+                      style: OTextStyle.labelMedium.copyWith(
+                        color: OColor.white,
+                      ),
+                    ),
+                  ],
                 ),
               ),
-              const SizedBox(width: OSpacing.m),
-              OText(
-                text: '$dayName, $dayDate$daySuffix $month',
-                style: OTextStyle.bodySmall.copyWith(
-                  color: OColor.gray600,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Search Results Section using the large card from "Your Interests"
+  Widget _buildSearchResultsSection() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: OSpacing.xs),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  OText(
+                    text: 'Search Results',
+                    style: OTextStyle.headingMedium.copyWith(
+                      color: OColor.gray800,
+                    ),
+                  ),
+                  const SizedBox(height: OSpacing.xxs),
+                  OText(
+                    text:
+                        '${_searchResults.length} ${_searchResults.length == 1 ? "event" : "events"} found',
+                    style: OTextStyle.bodySmall.copyWith(color: OColor.gray600),
+                  ),
+                ],
+              ),
+              GestureDetector(
+                onTap: () {
+                  _searchController.clear();
+                  _searchFocusNode.unfocus();
+                  _onSearchChanged('');
+                },
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: OColor.gray200,
+                    borderRadius: BorderRadius.circular(OCornerRadius.s),
+                  ),
+                  child: OText(
+                    text: 'Clear',
+                    style: OTextStyle.labelSmall.copyWith(
+                      color: OColor.gray700,
+                    ),
+                  ),
                 ),
               ),
             ],
           ),
-          // Profile avatar
-          Container(
-            width: 44,
-            height: 44,
-            decoration: BoxDecoration(
-              color: OColor.white,
-              shape: BoxShape.circle,
-              border: Border.all(color: OColor.gray200),
+          if (_isSearching) ...[
+            const SizedBox(height: OSpacing.xs),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(2),
+              child: LinearProgressIndicator(
+                minHeight: 3,
+                backgroundColor: OColor.gray200,
+                valueColor: AlwaysStoppedAnimation<Color>(OColor.green600),
+              ),
             ),
-            child: Icon(
-              FluentIcons.person_24_regular,
-              size: 24,
-              color: OColor.gray800,
+          ],
+          const SizedBox(height: OSpacing.m),
+
+          if (_isSearching && _searchResults.isEmpty)
+            Column(
+              children: const [
+                EventLargeCardShimmer(),
+                SizedBox(height: OSpacing.s),
+                EventLargeCardShimmer(),
+              ],
+            )
+          else if (_searchResults.isEmpty)
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 48),
+                child: Column(
+                  children: [
+                    Icon(
+                      FluentIcons.search_24_regular,
+                      size: 48,
+                      color: OColor.gray400,
+                    ),
+                    const SizedBox(height: OSpacing.s),
+                    OText(
+                      text: 'No events found for "$_searchQuery"',
+                      style: OTextStyle.bodyMedium.copyWith(
+                        color: OColor.gray700,
+                      ),
+                    ),
+                    const SizedBox(height: OSpacing.xxs),
+                    OText(
+                      text:
+                          'Try searching by a club name, category, or keyword.',
+                      style: OTextStyle.bodySmall.copyWith(
+                        color: OColor.gray500,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            )
+          else
+            Column(
+              children:
+                  _searchResults.map((event) {
+                    final isGoing =
+                        _likedEvents.any((e) => e.id == event.id) ||
+                        (event.userStatus?.isRegistered ?? false);
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: OSpacing.s),
+                      child: RepaintBoundary(
+                        child: EventListingLargeCard(
+                          event: event,
+                          interestedCount: _getEventInterestedCount(event),
+                          isGoing: isGoing,
+                          onTap: () => _openEventPopup(event),
+                          onGoingTap: () => _handleToggleLike(event),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+            ),
+        ],
+      ),
+    );
+  }
+
+  /// Top app bar with date, user greeting, and icon
+  Widget _buildHeader(BuildContext context) {
+    final now = DateTime.now();
+    final daySuffix = _getDaySuffix(now.day);
+    final formattedDate =
+        '${DateFormat('EEEE, d').format(now)}$daySuffix ${DateFormat('MMMM').format(now)}';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: OSpacing.m,
+      ).copyWith(top: OSpacing.m),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          // Left: date and greeting
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              OText(
+                text: formattedDate,
+                style: OTextStyle.labelSmall.copyWith(color: OColor.gray600),
+              ),
+              const SizedBox(height: OSpacing.xxs),
+              OText(
+                text: 'Events',
+                style: OTextStyle.headingLarge.copyWith(color: OColor.gray800),
+              ),
+            ],
+          ),
+          // Right: circular icon button
+          GestureDetector(
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const ClubsFestPage()),
+              );
+            },
+            child: Container(
+              width: 44,
+              height: 44,
+              decoration: BoxDecoration(
+                color: OColor.white,
+                shape: BoxShape.circle,
+                border: Border.all(color: OColor.gray200),
+              ),
+              child: Icon(
+                FluentIcons.grid_24_regular,
+                size: 24,
+                color: OColor.gray800,
+              ),
             ),
           ),
         ],
@@ -160,21 +781,27 @@ class EventsHomePage extends StatelessWidget {
           ),
         ),
         const SizedBox(height: OSpacing.s),
-        SizedBox(
-          height: 96,
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
-            itemCount: events.length,
-            separatorBuilder: (_, __) => const SizedBox(width: OSpacing.s),
-            itemBuilder: (context, index) {
-              final event = events[index];
-              return EventListingSmallCard(
-                event: event,
-                isGoing: index == 0,
-                onTap: () => showEventPopup(context, event: event),
-              );
-            },
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (final event in events) ...[
+                  RepaintBoundary(
+                    child: EventListingSmallCard(
+                      event: event,
+                      isGoing:
+                          _likedEvents.any((e) => e.id == event.id) ||
+                          (event.userStatus?.isRegistered ?? false),
+                      onTap: () => _openEventPopup(event),
+                    ),
+                  ),
+                  if (event != events.last) const SizedBox(width: OSpacing.s),
+                ],
+              ],
+            ),
           ),
         ),
       ],
@@ -193,26 +820,30 @@ class EventsHomePage extends StatelessWidget {
             title: 'Trending Events',
             actionLabel: 'Learn More',
             onActionTap: () {
-              // TODO: Navigate to trending
+              Navigator.pushNamed(context, EventsScreenWrapper.id);
             },
           ),
         ),
         const SizedBox(height: OSpacing.s),
-        SizedBox(
-          height: 270,
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
-            itemCount: events.length,
-            separatorBuilder: (_, __) => const SizedBox(width: OSpacing.s),
-            itemBuilder: (context, index) {
-              final event = events[index];
-              return EventListingMediumCard(
-                event: event,
-                goingCount: 350,
-                onTap: () => showEventPopup(context, event: event),
-              );
-            },
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (final event in events) ...[
+                  RepaintBoundary(
+                    child: EventListingMediumCard(
+                      event: event,
+                      goingCount: _getEventGoingCount(event),
+                      onTap: () => _openEventPopup(event),
+                    ),
+                  ),
+                  if (event != events.last) const SizedBox(width: OSpacing.s),
+                ],
+              ],
+            ),
           ),
         ),
       ],
@@ -232,25 +863,25 @@ class EventsHomePage extends StatelessWidget {
             actionLabel: 'Personalize',
             actionIcon: FluentIcons.settings_16_regular,
             onActionTap: () {
-              // TODO: Navigate to personalization
+              Navigator.pushNamed(context, EventsScreenWrapper.id);
             },
           ),
           const SizedBox(height: OSpacing.s),
           ...events.take(3).map((event) {
-            return Builder(
-              builder: (context) {
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: OSpacing.s),
-                  child: EventListingLargeCard(
-                    event: event,
-                    interestedCount: 350,
-                    onTap: () => showEventPopup(context, event: event),
-                    onGoingTap: () {
-                      // TODO: Toggle going status
-                    },
-                  ),
-                );
-              },
+            final isGoing =
+                _likedEvents.any((e) => e.id == event.id) ||
+                (event.userStatus?.isRegistered ?? false);
+            return Padding(
+              padding: const EdgeInsets.only(bottom: OSpacing.s),
+              child: RepaintBoundary(
+                child: EventListingLargeCard(
+                  event: event,
+                  interestedCount: _getEventInterestedCount(event),
+                  isGoing: isGoing,
+                  onTap: () => _openEventPopup(event),
+                  onGoingTap: () => _handleToggleLike(event),
+                ),
+              ),
             );
           }),
         ],
@@ -267,28 +898,32 @@ class EventsHomePage extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
           child: SectionHeader(
             icon: FluentIcons.history_24_regular,
-            title: 'Recently Attended',
+            title: 'Saved & Attended',
           ),
         ),
         const SizedBox(height: OSpacing.s),
-        SizedBox(
-          height: 168,
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
-            itemCount: events.length,
-            separatorBuilder: (_, __) => const SizedBox(width: OSpacing.s),
-            itemBuilder: (context, index) {
-              final event = events[index];
-              return EventsCompactCard(
-                event: event,
-                showFeedbackButton: true,
-                onTap: () => showEventPopup(context, event: event),
-                onFeedbackTap: () {
-                  // TODO: Open feedback form
-                },
-              );
-            },
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (final event in events) ...[
+                  RepaintBoundary(
+                    child: EventsCompactCard(
+                      event: event,
+                      showFeedbackButton: true,
+                      onTap: () => _openEventPopup(event),
+                      onFeedbackTap: () {
+                        _openEventPopup(event);
+                      },
+                    ),
+                  ),
+                  if (event != events.last) const SizedBox(width: OSpacing.s),
+                ],
+              ],
+            ),
           ),
         ),
       ],
@@ -307,21 +942,21 @@ class EventsHomePage extends StatelessWidget {
             title: 'Explore',
           ),
           const SizedBox(height: OSpacing.s),
-          ...events.take(3).map((event) {
-            return Builder(
-              builder: (context) {
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: OSpacing.s),
-                  child: EventListingLargeCard(
-                    event: event,
-                    interestedCount: 350,
-                    onTap: () => showEventPopup(context, event: event),
-                    onGoingTap: () {
-                      // TODO: Toggle going status
-                    },
-                  ),
-                );
-              },
+          ...events.take(5).map((event) {
+            final isGoing =
+                _likedEvents.any((e) => e.id == event.id) ||
+                (event.userStatus?.isRegistered ?? false);
+            return Padding(
+              padding: const EdgeInsets.only(bottom: OSpacing.s),
+              child: RepaintBoundary(
+                child: EventListingLargeCard(
+                  event: event,
+                  interestedCount: _getEventInterestedCount(event),
+                  isGoing: isGoing,
+                  onTap: () => _openEventPopup(event),
+                  onGoingTap: () => _handleToggleLike(event),
+                ),
+              ),
             );
           }),
         ],
@@ -331,19 +966,19 @@ class EventsHomePage extends StatelessWidget {
 
   /// Generate mock events matching the Figma placeholder data
   List<EventModel> _generateMockEvents() {
-    return List.generate(5, (index) {
+    return List.generate(3, (index) {
       return EventModel(
         id: 'mock_$index',
-        title: 'Rangmunch - Inter Hostel Stand Up',
+        clubId: 'club_$index',
+        name: 'Rangmunch - Inter Hostel Stand Up',
         description:
             'A stand-up comedy event featuring talented comedians from across hostels.',
-        clubOrg: "Students' Web Committee",
-        board: 'Cultural',
-        startDateTime: DateTime.now().copyWith(hour: 20, minute: 0),
-        endDateTime: DateTime.now().copyWith(hour: 22, minute: 0),
-        venue: 'Main Auditorium',
-        categories: ['Cultural', 'Comedy'],
-        v: 0,
+        clubName: "Students' Web Committee",
+        tags: ['Cultural', 'Comedy'],
+        startTime: DateTime.now().copyWith(hour: 20, minute: 0),
+        endTime: DateTime.now().copyWith(hour: 22, minute: 0),
+        date: DateTime.now(),
+        location: 'Main Auditorium',
       );
     });
   }

--- a/lib/pages/events/utils/event_formatters.dart
+++ b/lib/pages/events/utils/event_formatters.dart
@@ -1,0 +1,71 @@
+import 'package:intl/intl.dart';
+
+/// Utility functions for safe formatting and edge-case handling across the Events module.
+class EventFormatters {
+  /// Validates whether a string is a well-formed HTTP/HTTPS image URL
+  static bool isValidImageUrl(String? url) {
+    if (url == null || url.trim().isEmpty) return false;
+    final trimmed = url.trim().toLowerCase();
+    if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
+      return false;
+    }
+    final uri = Uri.tryParse(url.trim());
+    return uri != null && uri.hasAuthority;
+  }
+
+  /// Formats large numbers compactly: 950 -> "950", 1200 -> "1.2k", 25000 -> "25k", 1000000 -> "1M"
+  static String formatCount(int count) {
+    if (count <= 0) return '0';
+    if (count < 1000) return '$count';
+    if (count < 10000) {
+      final formatted = (count / 1000).toStringAsFixed(1);
+      return formatted.endsWith('.0') ? '${formatted.substring(0, formatted.length - 2)}k' : '${formatted}k';
+    }
+    if (count < 1000000) {
+      return '${(count / 1000).round()}k';
+    }
+    final formatted = (count / 1000000).toStringAsFixed(1);
+    return formatted.endsWith('.0') ? '${formatted.substring(0, formatted.length - 2)}M' : '${formatted}M';
+  }
+
+  static final DateFormat _dateFormat = DateFormat('dd MMM');
+  static final DateFormat _timeFormat = DateFormat('h:mm a');
+  static final DateFormat _fullDateFormat = DateFormat('dd MMM, h:mm a');
+
+  /// Formats single-day or multi-day event date & time ranges accurately
+  static String formatDateTimeRange(DateTime start, DateTime end) {
+    // If on same calendar day: "27 Aug, 8:00 PM - 10:00 PM"
+    if (start.year == end.year && start.month == end.month && start.day == end.day) {
+      return '${_dateFormat.format(start)}, ${_timeFormat.format(start)} - ${_timeFormat.format(end)}';
+    }
+
+    // If multi-day or overnight: "27 Aug, 8:00 PM - 28 Aug, 2:00 AM"
+    return '${_dateFormat.format(start)}, ${_timeFormat.format(start)} - ${_dateFormat.format(end)}, ${_timeFormat.format(end)}';
+  }
+
+  /// Formats date for large card: "27 Aug, 8:00 PM - 10:00 PM"
+  static String formatLargeCardDate(DateTime start, DateTime end) {
+    if (start.year == end.year && start.month == end.month && start.day == end.day) {
+      return '${_fullDateFormat.format(start)} - ${_timeFormat.format(end)}';
+    }
+    return '${_fullDateFormat.format(start)} - ${_fullDateFormat.format(end)}';
+  }
+
+  /// Sanitizes title / text with fallback
+  static String sanitizeText(String? text, {String fallback = 'Untitled Event'}) {
+    if (text == null || text.trim().isEmpty) return fallback;
+    return text.trim();
+  }
+
+  /// Sanitizes venue with fallback
+  static String sanitizeVenue(String? venue) {
+    if (venue == null || venue.trim().isEmpty) return 'Campus';
+    return venue.trim();
+  }
+
+  /// Sanitizes organizer / club with fallback
+  static String sanitizeClub(String? club) {
+    if (club == null || club.trim().isEmpty) return 'Club Organizer';
+    return club.trim();
+  }
+}

--- a/lib/pages/events/widgets/components/event_avatar_stack.dart
+++ b/lib/pages/events/widgets/components/event_avatar_stack.dart
@@ -1,0 +1,48 @@
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:onestop_ui/index.dart';
+
+/// Reusable overlapping avatar stack for attendee previews.
+class EventAvatarStack extends StatelessWidget {
+  final int count;
+  final double size;
+  final double overlap;
+
+  const EventAvatarStack({
+    super.key,
+    this.count = 3,
+    this.size = 24.0,
+    this.overlap = 20.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final totalWidth = size + (count - 1) * overlap;
+
+    return SizedBox(
+      width: totalWidth,
+      height: size,
+      child: Stack(
+        children: List.generate(count, (index) {
+          return Positioned(
+            left: index * overlap,
+            child: Container(
+              width: size,
+              height: size,
+              decoration: BoxDecoration(
+                color: OColor.gray300,
+                shape: BoxShape.circle,
+                border: Border.all(color: OColor.white, width: 2),
+              ),
+              child: Icon(
+                FluentIcons.person_12_regular,
+                size: size * 0.5,
+                color: OColor.gray600,
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/lib/pages/events/widgets/components/event_going_button.dart
+++ b/lib/pages/events/widgets/components/event_going_button.dart
@@ -1,0 +1,58 @@
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:onestop_ui/index.dart';
+
+/// Isolated interactive "I'm Going" button wrapped in [RepaintBoundary].
+class EventGoingButton extends StatelessWidget {
+  final bool isGoing;
+  final VoidCallback? onTap;
+
+  const EventGoingButton({
+    super.key,
+    required this.isGoing,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          padding: const EdgeInsets.symmetric(
+            horizontal: OSpacing.m,
+            vertical: OSpacing.xs,
+          ),
+          decoration: BoxDecoration(
+            color: isGoing ? OColor.green100 : Colors.transparent,
+            borderRadius: BorderRadius.circular(OCornerRadius.m),
+            border: Border.all(
+              color: isGoing ? OColor.green600 : OColor.gray300,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                isGoing
+                    ? FluentIcons.checkmark_16_filled
+                    : FluentIcons.heart_16_regular,
+                size: 16,
+                color: OColor.green600,
+              ),
+              const SizedBox(width: OSpacing.xxs),
+              OText(
+                text: isGoing ? "Going" : "I'm Going",
+                style: OTextStyle.labelMedium.copyWith(
+                  color: OColor.green600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/events/widgets/components/event_network_image.dart
+++ b/lib/pages/events/widgets/components/event_network_image.dart
@@ -1,0 +1,119 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:onestop_dev/pages/events/utils/event_formatters.dart';
+import 'package:onestop_ui/index.dart';
+import 'package:shimmer/shimmer.dart';
+
+/// High-performance network image widget for Events.
+///
+/// Features:
+/// - Fast caching via [CachedNetworkImage] with memory size constraints.
+/// - Themed shimmer placeholder while loading.
+/// - Clean fallback placeholder when URL is null, empty, or invalid.
+class EventNetworkImage extends StatelessWidget {
+  final String? imageUrl;
+  final double? width;
+  final double? height;
+  final double? aspectRatio;
+  final BorderRadius? borderRadius;
+  final bool isCircular;
+  final BoxFit fit;
+
+  const EventNetworkImage({
+    super.key,
+    required this.imageUrl,
+    this.width,
+    this.height,
+    this.aspectRatio,
+    this.borderRadius,
+    this.isCircular = false,
+    this.fit = BoxFit.cover,
+  });
+
+  const EventNetworkImage.banner({
+    super.key,
+    required this.imageUrl,
+    this.aspectRatio = 16 / 9,
+    this.borderRadius,
+    this.fit = BoxFit.cover,
+  })  : width = null,
+        height = null,
+        isCircular = false;
+
+  const EventNetworkImage.avatar({
+    super.key,
+    required this.imageUrl,
+    this.width = 48,
+    this.height = 48,
+    this.borderRadius,
+    this.fit = BoxFit.cover,
+  })  : aspectRatio = null,
+        isCircular = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final isValid = EventFormatters.isValidImageUrl(imageUrl);
+
+    Widget imageWidget;
+    if (isValid) {
+      final cacheWidth = width != null ? (width! * 2).toInt() : (isCircular ? 96 : 600);
+      final cacheHeight = height != null ? (height! * 2).toInt() : (isCircular ? 96 : null);
+
+      imageWidget = CachedNetworkImage(
+        imageUrl: imageUrl!.trim(),
+        width: width,
+        height: height,
+        fit: fit,
+        memCacheWidth: cacheWidth,
+        memCacheHeight: cacheHeight,
+        fadeInDuration: const Duration(milliseconds: 200),
+        placeholder: (_, __) => _buildShimmerPlaceholder(),
+        errorWidget: (_, __, ___) => _buildFallbackPlaceholder(),
+      );
+    } else {
+      imageWidget = _buildFallbackPlaceholder();
+    }
+
+    if (isCircular) {
+      return ClipOval(child: SizedBox(width: width, height: height, child: imageWidget));
+    }
+
+    if (borderRadius != null) {
+      imageWidget = ClipRRect(borderRadius: borderRadius!, child: imageWidget);
+    }
+
+    if (aspectRatio != null) {
+      return AspectRatio(aspectRatio: aspectRatio!, child: imageWidget);
+    }
+
+    return imageWidget;
+  }
+
+  Widget _buildShimmerPlaceholder() {
+    return Shimmer.fromColors(
+      baseColor: OColor.gray200,
+      highlightColor: OColor.gray100,
+      child: Container(
+        width: width ?? double.infinity,
+        height: height ?? double.infinity,
+        color: OColor.white,
+      ),
+    );
+  }
+
+  Widget _buildFallbackPlaceholder() {
+    return Container(
+      width: width ?? double.infinity,
+      height: height ?? double.infinity,
+      color: OColor.gray200,
+      child: Center(
+        child: Icon(
+          isCircular ? FluentIcons.calendar_24_regular : FluentIcons.image_24_regular,
+          size: isCircular ? 24 : 40,
+          color: OColor.gray400,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/events/widgets/event_listing_large_card.dart
+++ b/lib/pages/events/widgets/event_listing_large_card.dart
@@ -1,13 +1,15 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:onestop_dev/models/event_scheduler/event_model.dart';
+import 'package:onestop_dev/pages/events/utils/event_formatters.dart';
+import 'package:onestop_dev/pages/events/widgets/components/event_avatar_stack.dart';
+import 'package:onestop_dev/pages/events/widgets/components/event_going_button.dart';
+import 'package:onestop_dev/pages/events/widgets/components/event_network_image.dart';
 import 'package:onestop_ui/index.dart';
 
 /// Large event card used in the "Your Interests" and "Explore" sections.
 ///
-/// Shows image, title with chevron, tags, location, date, organizer profile,
-/// divider, avatar group + interested count, and "I'm Going" button.
+/// Composed of [EventNetworkImage], [OTag], [EventAvatarStack], and [EventGoingButton].
 class EventListingLargeCard extends StatelessWidget {
   final EventModel event;
   final int interestedCount;
@@ -26,94 +28,72 @@ class EventListingLargeCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        width: double.infinity,
-        padding: const EdgeInsets.all(OSpacing.s),
-        decoration: BoxDecoration(
-          color: OColor.white,
-          borderRadius: BorderRadius.circular(OCornerRadius.m),
-          border: Border.all(color: OColor.gray200),
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Image preview
-            _buildImagePreview(),
-            const SizedBox(height: OSpacing.s),
-            // Title row with chevron
-            _buildTitleRow(),
-            const SizedBox(height: OSpacing.s),
-            // Tags
-            _buildTags(),
-            const SizedBox(height: OSpacing.s),
-            // Location and date
-            _buildLocationAndDate(),
-            const SizedBox(height: OSpacing.s),
-            // Organizer profile
-            _buildOrganizerProfile(),
-            const SizedBox(height: OSpacing.s),
-            // Divider
-            Divider(height: 1, color: OColor.gray200),
-            const SizedBox(height: OSpacing.s),
-            // Footer: avatar group + interested count + Going button
-            _buildFooter(),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildImagePreview() {
     final imageUrl = event.compressedImageUrl ?? event.imageUrl;
-    if (imageUrl != null) {
-      return AspectRatio(
-        aspectRatio: 358 / 201,
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(OCornerRadius.s),
-          child: Image.network(
-            imageUrl,
-            fit: BoxFit.cover,
-            errorBuilder: (_, __, ___) => _imagePlaceholder(),
-          ),
-        ),
-      );
-    }
-    return AspectRatio(
-      aspectRatio: 358 / 201,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(OCornerRadius.s),
-        child: _imagePlaceholder(),
-      ),
-    );
-  }
 
-  Widget _imagePlaceholder() {
     return Container(
-      color: OColor.gray200,
-      child: Center(
-        child: Icon(
-          FluentIcons.image_24_regular,
-          size: 48,
-          color: OColor.gray400,
-        ),
+      width: double.infinity,
+      padding: const EdgeInsets.all(OSpacing.s),
+      decoration: BoxDecoration(
+        color: OColor.white,
+        borderRadius: BorderRadius.circular(OCornerRadius.m),
+        border: Border.all(color: OColor.gray200),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          GestureDetector(
+            onTap: onTap,
+            behavior: HitTestBehavior.opaque,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // Image preview with progressive shimmer & caching
+                EventNetworkImage.banner(
+                  imageUrl: imageUrl,
+                  aspectRatio: 358 / 201,
+                  borderRadius: BorderRadius.circular(OCornerRadius.s),
+                ),
+                const SizedBox(height: OSpacing.s),
+                // Title row with chevron
+                _buildTitleRow(),
+                const SizedBox(height: OSpacing.s),
+                // Tags using OTag from onestop_ui
+                _buildTags(),
+                const SizedBox(height: OSpacing.s),
+                // Location and date
+                _buildLocationAndDate(),
+                const SizedBox(height: OSpacing.s),
+                // Organizer profile
+                _buildOrganizerProfile(),
+              ],
+            ),
+          ),
+          const SizedBox(height: OSpacing.s),
+          // Divider
+          Divider(height: 1, color: OColor.gray200),
+          const SizedBox(height: OSpacing.s),
+          // Footer: avatar group + interested count + Going button
+          _buildFooter(),
+        ],
       ),
     );
   }
 
   Widget _buildTitleRow() {
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Expanded(
           child: OText(
-            text: event.title,
+            text: EventFormatters.sanitizeText(event.title),
             style: OTextStyle.headingSmall.copyWith(
               color: OColor.gray800,
             ),
             maxLines: 2,
+            overflow: TextOverflow.ellipsis,
           ),
         ),
         const SizedBox(width: OSpacing.m),
@@ -127,33 +107,26 @@ class EventListingLargeCard extends StatelessWidget {
   }
 
   Widget _buildTags() {
-    if (event.categories.isEmpty) return const SizedBox.shrink();
+    final validTags = event.categories.where((c) => c.trim().isNotEmpty).toList();
+    if (validTags.isEmpty) return const SizedBox.shrink();
 
     return Wrap(
-      spacing: OSpacing.m,
+      spacing: OSpacing.s,
       runSpacing: OSpacing.xs,
-      children: event.categories.take(2).toList().asMap().entries.map((entry) {
+      children: validTags.take(2).toList().asMap().entries.map((entry) {
         final index = entry.key;
-        final category = entry.value;
-        final color = index == 0 ? OColor.blue600 : OColor.green600;
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          decoration: BoxDecoration(
-            color: OColor.gray100,
-            borderRadius: BorderRadius.circular(OCornerRadius.l),
-          ),
-          child: OText(
-            text: category.toUpperCase(),
-            style: OTextStyle.labelSmall.copyWith(color: color),
-          ),
+        final category = entry.value.trim();
+        return OTag(
+          type: index == 0 ? TagType.accentColor : TagType.neutral,
+          label: category.toUpperCase(),
         );
       }).toList(),
     );
   }
 
   Widget _buildLocationAndDate() {
-    final dateFormat = DateFormat("dd MMM, h:mm a");
-    final timeFormat = DateFormat("h:mm a");
+    final dateRange = EventFormatters.formatLargeCardDate(event.startDateTime, event.endDateTime);
+    final venue = EventFormatters.sanitizeVenue(event.venue);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -165,7 +138,7 @@ class EventListingLargeCard extends StatelessWidget {
             const SizedBox(width: OSpacing.xxs),
             Expanded(
               child: OText(
-                text: event.venue,
+                text: venue,
                 style: OTextStyle.labelMedium.copyWith(color: OColor.gray600),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
@@ -181,8 +154,7 @@ class EventListingLargeCard extends StatelessWidget {
             const SizedBox(width: OSpacing.xxs),
             Expanded(
               child: OText(
-                text:
-                    '${dateFormat.format(event.startDateTime)} - ${timeFormat.format(event.endDateTime)}',
+                text: dateRange,
                 style: OTextStyle.labelMedium.copyWith(color: OColor.gray600),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
@@ -195,6 +167,8 @@ class EventListingLargeCard extends StatelessWidget {
   }
 
   Widget _buildOrganizerProfile() {
+    final clubName = EventFormatters.sanitizeClub(event.clubOrg);
+
     return Row(
       children: [
         Container(
@@ -213,7 +187,7 @@ class EventListingLargeCard extends StatelessWidget {
         const SizedBox(width: OSpacing.xs),
         Expanded(
           child: OText(
-            text: event.clubOrg,
+            text: clubName,
             style: OTextStyle.labelMedium.copyWith(color: OColor.gray800),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
@@ -224,84 +198,39 @@ class EventListingLargeCard extends StatelessWidget {
   }
 
   Widget _buildFooter() {
+    final safeCount = interestedCount > 0 ? interestedCount : 0;
+    final compactCount = EventFormatters.formatCount(safeCount);
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        // Avatar group + interested count
-        Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildAvatarGroup(),
-            const SizedBox(width: OSpacing.xxs),
-            if (interestedCount > 0)
-              OText(
-                text: '$interestedCount INTERESTED',
-                style: OTextStyle.labelSmall.copyWith(color: OColor.blue500),
-              ),
-          ],
-        ),
-        // I'm Going button
-        GestureDetector(
-          onTap: onGoingTap,
-          child: Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: OSpacing.m,
-              vertical: OSpacing.xs,
-            ),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(OCornerRadius.m),
-              border: Border.all(color: OColor.gray300),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  isGoing
-                      ? FluentIcons.heart_16_filled
-                      : FluentIcons.heart_16_regular,
-                  size: 16,
-                  color: OColor.green600,
-                ),
+        // Avatar stack + interested count
+        Flexible(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const EventAvatarStack(count: 3, size: 24, overlap: 20),
+              if (safeCount > 0) ...[
                 const SizedBox(width: OSpacing.xxs),
-                OText(
-                  text: "I'm Going",
-                  style: OTextStyle.labelMedium.copyWith(
-                    color: OColor.green600,
+                Flexible(
+                  child: OText(
+                    text: '$compactCount INTERESTED',
+                    style: OTextStyle.labelSmall.copyWith(color: OColor.blue500),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
               ],
-            ),
+            ],
           ),
         ),
+        const SizedBox(width: OSpacing.xs),
+        // Isolated I'm Going button
+        EventGoingButton(
+          isGoing: isGoing,
+          onTap: onGoingTap,
+        ),
       ],
-    );
-  }
-
-  Widget _buildAvatarGroup() {
-    return SizedBox(
-      width: 64,
-      height: 24,
-      child: Stack(
-        children: List.generate(3, (index) {
-          return Positioned(
-            left: index * 20.0,
-            child: Container(
-              width: 24,
-              height: 24,
-              decoration: BoxDecoration(
-                color: OColor.gray300,
-                shape: BoxShape.circle,
-                border: Border.all(color: OColor.white, width: 2),
-              ),
-              child: Icon(
-                FluentIcons.person_12_regular,
-                size: 12,
-                color: OColor.gray600,
-              ),
-            ),
-          );
-        }),
-      ),
     );
   }
 }

--- a/lib/pages/events/widgets/event_listing_medium_card.dart
+++ b/lib/pages/events/widgets/event_listing_medium_card.dart
@@ -1,13 +1,13 @@
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:onestop_dev/models/event_scheduler/event_model.dart';
+import 'package:onestop_dev/pages/events/utils/event_formatters.dart';
+import 'package:onestop_dev/pages/events/widgets/components/event_avatar_stack.dart';
+import 'package:onestop_dev/pages/events/widgets/components/event_network_image.dart';
 import 'package:onestop_ui/index.dart';
 
 /// Medium event card used in the "Trending Events" horizontal scroll.
 ///
-/// Shows an image preview, event title, date/time, location,
-/// avatar group, and "+N Going" count.
+/// Composed of [EventNetworkImage] and [EventAvatarStack].
 class EventListingMediumCard extends StatelessWidget {
   final EventModel event;
   final int goingCount;
@@ -22,6 +22,10 @@ class EventListingMediumCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final safeCount = goingCount > 0 ? goingCount : 0;
+    final compactGoing = EventFormatters.formatCount(safeCount);
+    final imageUrl = event.compressedImageUrl ?? event.imageUrl;
+
     return GestureDetector(
       onTap: onTap,
       child: Container(
@@ -36,8 +40,15 @@ class EventListingMediumCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            // Image preview
-            _buildImagePreview(),
+            // Image preview with progressive shimmer & caching
+            EventNetworkImage.banner(
+              imageUrl: imageUrl,
+              aspectRatio: 16 / 9,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(OCornerRadius.s),
+                topRight: Radius.circular(OCornerRadius.s),
+              ),
+            ),
             // Content
             Padding(
               padding: const EdgeInsets.all(OSpacing.s),
@@ -45,10 +56,10 @@ class EventListingMediumCard extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   // Title
-                  SizedBox(
-                    height: 40,
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: 36),
                     child: OText(
-                      text: event.title,
+                      text: EventFormatters.sanitizeText(event.title),
                       style: OTextStyle.labelMedium.copyWith(
                         color: OColor.gray800,
                       ),
@@ -59,7 +70,10 @@ class EventListingMediumCard extends StatelessWidget {
                   const SizedBox(height: OSpacing.xs),
                   // Date/time
                   OText(
-                    text: _formatDateTime(),
+                    text: EventFormatters.formatDateTimeRange(
+                      event.startDateTime,
+                      event.endDateTime,
+                    ),
                     style: OTextStyle.labelMedium.copyWith(
                       color: OColor.gray600,
                     ),
@@ -69,25 +83,31 @@ class EventListingMediumCard extends StatelessWidget {
                   const SizedBox(height: OSpacing.xxs),
                   // Location
                   OText(
-                    text: event.venue,
+                    text: EventFormatters.sanitizeVenue(event.venue),
                     style: OTextStyle.labelMedium.copyWith(
                       color: OColor.gray600,
                     ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  // Avatar group + going count
+                  const SizedBox(height: OSpacing.xs),
+                  // Avatar stack + going count
                   Row(
                     children: [
-                      _buildAvatarGroup(),
-                      const SizedBox(width: OSpacing.xxs),
-                      if (goingCount > 0)
-                        OText(
-                          text: '+$goingCount GOING',
-                          style: OTextStyle.labelSmall.copyWith(
-                            color: OColor.blue500,
+                      const EventAvatarStack(count: 3, size: 24, overlap: 20),
+                      if (safeCount > 0) ...[
+                        const SizedBox(width: OSpacing.xxs),
+                        Flexible(
+                          child: OText(
+                            text: '+$compactGoing GOING',
+                            style: OTextStyle.labelSmall.copyWith(
+                              color: OColor.blue500,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                           ),
                         ),
+                      ],
                     ],
                   ),
                 ],
@@ -97,78 +117,5 @@ class EventListingMediumCard extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  Widget _buildImagePreview() {
-    final imageUrl = event.compressedImageUrl ?? event.imageUrl;
-    if (imageUrl != null) {
-      return AspectRatio(
-        aspectRatio: 358 / 201,
-        child: ClipRRect(
-          borderRadius: const BorderRadius.only(
-            topLeft: Radius.circular(OCornerRadius.s),
-            topRight: Radius.circular(OCornerRadius.s),
-          ),
-          child: Image.network(
-            imageUrl,
-            fit: BoxFit.cover,
-            errorBuilder: (_, __, ___) => _imagePlaceholder(),
-          ),
-        ),
-      );
-    }
-    return AspectRatio(
-      aspectRatio: 358 / 201,
-      child: _imagePlaceholder(),
-    );
-  }
-
-  Widget _imagePlaceholder() {
-    return Container(
-      color: OColor.gray200,
-      child: Center(
-        child: Icon(
-          FluentIcons.image_24_regular,
-          size: 48,
-          color: OColor.gray400,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildAvatarGroup() {
-    return SizedBox(
-      width: 64,
-      height: 24,
-      child: Stack(
-        children: List.generate(3, (index) {
-          return Positioned(
-            left: index * 20.0,
-            child: Container(
-              width: 24,
-              height: 24,
-              decoration: BoxDecoration(
-                color: OColor.gray300,
-                shape: BoxShape.circle,
-                border: Border.all(color: OColor.white, width: 2),
-              ),
-              child: Icon(
-                FluentIcons.person_12_regular,
-                size: 12,
-                color: OColor.gray600,
-              ),
-            ),
-          );
-        }),
-      ),
-    );
-  }
-
-  String _formatDateTime() {
-    final dateFormat = DateFormat('dd MMM');
-    final timeFormat = DateFormat('h:mm a');
-    return '${dateFormat.format(event.startDateTime)}, '
-        '${timeFormat.format(event.startDateTime)} - '
-        '${timeFormat.format(event.endDateTime)}';
   }
 }

--- a/lib/pages/events/widgets/event_listing_small_card.dart
+++ b/lib/pages/events/widgets/event_listing_small_card.dart
@@ -1,12 +1,13 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:onestop_dev/models/event_scheduler/event_model.dart';
+import 'package:onestop_dev/pages/events/utils/event_formatters.dart';
+import 'package:onestop_dev/pages/events/widgets/components/event_network_image.dart';
 import 'package:onestop_ui/index.dart';
 
 /// Small horizontal event card used in the "Happening Today" section.
 ///
-/// Shows avatar, event name, optional "I'm Going" badge,
-/// time + location, and a trailing chevron.
+/// Composed of [EventNetworkImage.avatar], title, venue, and trailing chevron.
 class EventListingSmallCard extends StatelessWidget {
   final EventModel event;
   final bool isGoing;
@@ -21,6 +22,10 @@ class EventListingSmallCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final title = EventFormatters.sanitizeText(event.title);
+    final venue = EventFormatters.sanitizeVenue(event.venue);
+    final imageUrl = event.compressedImageUrl ?? event.imageUrl;
+
     return GestureDetector(
       onTap: onTap,
       child: Container(
@@ -33,8 +38,12 @@ class EventListingSmallCard extends StatelessWidget {
         ),
         child: Row(
           children: [
-            // Avatar
-            _buildAvatar(),
+            // Avatar with progressive shimmer & caching
+            EventNetworkImage.avatar(
+              imageUrl: imageUrl,
+              width: 48,
+              height: 48,
+            ),
             const SizedBox(width: OSpacing.s),
             // Content
             Expanded(
@@ -45,7 +54,7 @@ class EventListingSmallCard extends StatelessWidget {
                   children: [
                     // Event name
                     OText(
-                      text: event.title,
+                      text: title,
                       style: OTextStyle.bodyMedium.copyWith(
                         color: OColor.gray800,
                       ),
@@ -62,7 +71,7 @@ class EventListingSmallCard extends StatelessWidget {
                             size: 16,
                             color: OColor.green600,
                           ),
-                          //const SizedBox(width: OSpacing.xxs),
+                          const SizedBox(width: OSpacing.xxs),
                           OText(
                             text: "I'M GOING",
                             style: OTextStyle.labelSmall.copyWith(
@@ -72,10 +81,10 @@ class EventListingSmallCard extends StatelessWidget {
                         ],
                       ),
                     ],
-                    //const SizedBox(height: OSpacing.xxs),
+                    const SizedBox(height: OSpacing.xxs),
                     // Time and location
                     OText(
-                      text: event.venue,
+                      text: venue,
                       style: OTextStyle.bodySmall.copyWith(
                         color: OColor.gray600,
                       ),
@@ -95,37 +104,6 @@ class EventListingSmallCard extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-
-  Widget _buildAvatar() {
-    if (event.compressedImageUrl != null) {
-      return ClipOval(
-        child: Image.network(
-          event.compressedImageUrl!,
-          width: 48,
-          height: 48,
-          fit: BoxFit.cover,
-          errorBuilder: (_, __, ___) => _placeholderAvatar(),
-        ),
-      );
-    }
-    return _placeholderAvatar();
-  }
-
-  Widget _placeholderAvatar() {
-    return Container(
-      width: 48,
-      height: 48,
-      decoration: BoxDecoration(
-        color: OColor.gray200,
-        shape: BoxShape.circle,
-      ),
-      child: Icon(
-        FluentIcons.calendar_24_regular,
-        size: 24,
-        color: OColor.gray600,
       ),
     );
   }

--- a/lib/pages/events/widgets/event_popup.dart
+++ b/lib/pages/events/widgets/event_popup.dart
@@ -1,15 +1,23 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:onestop_dev/functions/utility/show_snackbar.dart';
 import 'package:onestop_dev/models/event_scheduler/event_model.dart';
+import 'package:onestop_dev/pages/events/widgets/components/event_network_image.dart';
 import 'package:onestop_dev/pages/events/widgets/poc_modal.dart';
+import 'package:onestop_dev/repository/events_api_repository.dart';
+import 'package:onestop_dev/stores/login_store.dart';
 import 'package:onestop_ui/index.dart';
 
 /// Shows the event detail popup as a modal bottom sheet.
-///
-/// Follows the same pattern as [showContactProfileSheet] in contact_dialog.dart.
-void showEventPopup(BuildContext context, {required EventModel event}) {
-  showModalBottomSheet(
+Future<void> showEventPopup(
+  BuildContext context, {
+  required EventModel event,
+  bool? isInitiallyInterested,
+  bool? isInitiallyRegistered,
+  Function(bool isInterested, bool isRegistered)? onStatusChanged,
+}) async {
+  await showModalBottomSheet(
     context: context,
     backgroundColor: Colors.transparent,
     isScrollControlled: true,
@@ -22,6 +30,9 @@ void showEventPopup(BuildContext context, {required EventModel event}) {
           return _EventPopupContent(
             event: event,
             scrollController: scrollController,
+            isInitiallyInterested: isInitiallyInterested,
+            isInitiallyRegistered: isInitiallyRegistered,
+            onStatusChanged: onStatusChanged,
           );
         },
       );
@@ -29,21 +40,116 @@ void showEventPopup(BuildContext context, {required EventModel event}) {
   );
 }
 
-class _EventPopupContent extends StatelessWidget {
+class _EventPopupContent extends StatefulWidget {
   final EventModel event;
   final ScrollController scrollController;
+  final bool? isInitiallyInterested;
+  final bool? isInitiallyRegistered;
+  final Function(bool isInterested, bool isRegistered)? onStatusChanged;
 
   const _EventPopupContent({
     required this.event,
     required this.scrollController,
+    this.isInitiallyInterested,
+    this.isInitiallyRegistered,
+    this.onStatusChanged,
   });
+
+  @override
+  State<_EventPopupContent> createState() => _EventPopupContentState();
+}
+
+class _EventPopupContentState extends State<_EventPopupContent> {
+  late EventModel event;
+  bool isInterested = false;
+  bool isRegistered = false;
+  bool isActionLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    event = widget.event;
+    isInterested = widget.isInitiallyInterested ??
+        (event.userStatus?.isInterested ?? false);
+    isRegistered = widget.isInitiallyRegistered ??
+        (event.userStatus?.isRegistered ?? false);
+    _fetchFullDetails();
+  }
+
+  Future<void> _fetchFullDetails() async {
+    final studentId = LoginStore.userData['_id'] ?? LoginStore.userData['rollNo'] ?? '';
+    final detailed = await EventsAPIRepository().getEventDetails(
+      event.id,
+      studentId: studentId,
+    );
+    if (detailed != null && mounted) {
+      setState(() {
+        event = detailed;
+        if (widget.isInitiallyInterested == null) {
+          isInterested = detailed.userStatus?.isInterested ?? isInterested;
+        }
+        if (widget.isInitiallyRegistered == null) {
+          isRegistered = detailed.userStatus?.isRegistered ?? isRegistered;
+        }
+      });
+    }
+  }
+
+  Future<void> _toggleLikeOrInterest() async {
+    final rollNo = LoginStore.userData['rollNo']?.toString() ??
+        LoginStore.userData['rollno']?.toString() ??
+        LoginStore.userData['rollNumber']?.toString() ??
+        'guest';
+    final email = LoginStore.userData['outlookEmail']?.toString() ??
+        LoginStore.userData['email']?.toString() ??
+        'guest@iitg.ac.in';
+
+    final newStatus = !isInterested;
+    setState(() {
+      isInterested = newStatus;
+      isActionLoading = true;
+    });
+    widget.onStatusChanged?.call(isInterested, isRegistered);
+
+    try {
+      final res = await EventsAPIRepository().toggleLikeEvent(
+        rollNo: rollNo,
+        email: email,
+        eventId: event.id,
+        like: newStatus,
+      );
+
+      if (mounted) {
+        setState(() {
+          isActionLoading = false;
+          if (res != null) {
+            isInterested = res.like;
+          }
+        });
+        widget.onStatusChanged?.call(isInterested, isRegistered);
+        showSnackBar(
+          isInterested ? "Added to your interested events!" : "Removed from interested events",
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          isActionLoading = false;
+        });
+        widget.onStatusChanged?.call(isInterested, isRegistered);
+        showSnackBar(
+          isInterested ? "Added to your interested events!" : "Removed from interested events",
+        );
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      decoration:  BoxDecoration(
+      decoration: BoxDecoration(
         color: OColor.white,
-        borderRadius: BorderRadius.vertical(
+        borderRadius: const BorderRadius.vertical(
           top: Radius.circular(32),
         ),
       ),
@@ -64,7 +170,7 @@ class _EventPopupContent extends StatelessWidget {
           // Scrollable content
           Expanded(
             child: ListView(
-              controller: scrollController,
+              controller: widget.scrollController,
               padding: const EdgeInsets.symmetric(horizontal: OSpacing.m)
                   .copyWith(top: OSpacing.m, bottom: OSpacing.l),
               children: [
@@ -89,38 +195,42 @@ class _EventPopupContent extends StatelessWidget {
                 const SizedBox(height: OSpacing.l),
 
                 // Special Guests
-                _buildSpecialGuests(),
-                const SizedBox(height: OSpacing.l),
+                if (event.guest.isNotEmpty) ...[
+                  _buildSpecialGuests(),
+                  const SizedBox(height: OSpacing.l),
+                ],
 
                 // Description
-                _buildSection(
-                  label: 'Description',
-                  content: event.description,
-                ),
-                const SizedBox(height: OSpacing.s),
-
-                // Divider
-                Divider(height: 1, color: OColor.gray200),
-                const SizedBox(height: OSpacing.l),
+                if (event.description != null && event.description!.isNotEmpty) ...[
+                  _buildSection(
+                    label: 'Description',
+                    content: event.description!,
+                  ),
+                  const SizedBox(height: OSpacing.s),
+                  Divider(height: 1, color: OColor.gray200),
+                  const SizedBox(height: OSpacing.l),
+                ],
 
                 // Who should attend
-                _buildSection(
-                  label: 'Who should attend?',
-                  content: event.description,
-                ),
-                const SizedBox(height: OSpacing.s),
-
-                // Divider
-                Divider(height: 1, color: OColor.gray200),
-                const SizedBox(height: OSpacing.l),
+                if (event.whoShouldAttend != null && event.whoShouldAttend!.isNotEmpty) ...[
+                  _buildSection(
+                    label: 'Who should attend?',
+                    content: event.whoShouldAttend!,
+                  ),
+                  const SizedBox(height: OSpacing.s),
+                  Divider(height: 1, color: OColor.gray200),
+                  const SizedBox(height: OSpacing.l),
+                ],
 
                 // Posted By
                 _buildPostedBy(),
                 const SizedBox(height: OSpacing.l),
 
                 // POCs
-                _buildPOCs(context),
-                const SizedBox(height: OSpacing.l),
+                if (event.poc.isNotEmpty) ...[
+                  _buildPOCs(context),
+                  const SizedBox(height: OSpacing.l),
+                ],
               ],
             ),
           ),
@@ -150,11 +260,11 @@ class _EventPopupContent extends StatelessWidget {
           child: Container(
             width: 40,
             height: 40,
-            decoration:  BoxDecoration(
+            decoration: BoxDecoration(
               color: OColor.gray100,
               shape: BoxShape.circle,
             ),
-            child:  Icon(
+            child: Icon(
               FluentIcons.dismiss_24_regular,
               size: 24,
               color: OColor.gray800,
@@ -165,34 +275,13 @@ class _EventPopupContent extends StatelessWidget {
     );
   }
 
-  /// Image preview with rounded corners
+  /// Image preview with progressive shimmer & caching
   Widget _buildImagePreview() {
     final imageUrl = event.imageUrl ?? event.compressedImageUrl;
-    return AspectRatio(
+    return EventNetworkImage.banner(
+      imageUrl: imageUrl,
       aspectRatio: 358 / 201,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(OCornerRadius.s),
-        child: imageUrl != null
-            ? Image.network(
-                imageUrl,
-                fit: BoxFit.cover,
-                errorBuilder: (_, __, ___) => _imagePlaceholder(),
-              )
-            : _imagePlaceholder(),
-      ),
-    );
-  }
-
-  Widget _imagePlaceholder() {
-    return Container(
-      color: OColor.gray200,
-      child:  Center(
-        child: Icon(
-          FluentIcons.image_24_regular,
-          size: 48,
-          color: OColor.gray400,
-        ),
-      ),
+      borderRadius: BorderRadius.circular(OCornerRadius.s),
     );
   }
 
@@ -202,62 +291,81 @@ class _EventPopupContent extends StatelessWidget {
       height: 48,
       child: Row(
         children: [
-          // Register button (primary, green filled)
+          // Register button
           Expanded(
-            child: Container(
-              decoration: BoxDecoration(
-                color: OColor.green600,
-                borderRadius: BorderRadius.circular(OCornerRadius.m),
-                boxShadow: const [
-                  BoxShadow(
-                    color: Color(0x0A000000),
-                    blurRadius: 20,
-                  ),
-                ],
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                   Icon(
-                    FluentIcons.edit_16_regular,
-                    size: 16,
-                    color: OColor.white,
-                  ),
-                  const SizedBox(width: OSpacing.xxs),
-                  OText(
-                    text: 'Register',
-                    style: OTextStyle.labelMedium.copyWith(
+            child: GestureDetector(
+              onTap: () {
+                setState(() {
+                  isRegistered = !isRegistered;
+                });
+                widget.onStatusChanged?.call(isInterested, isRegistered);
+                showSnackBar(isRegistered
+                    ? "Registered for ${event.title}"
+                    : "Registration cancelled for ${event.title}");
+              },
+              child: Container(
+                decoration: BoxDecoration(
+                  color: isRegistered ? OColor.green700 : OColor.green600,
+                  borderRadius: BorderRadius.circular(OCornerRadius.m),
+                  boxShadow: const [
+                    BoxShadow(
+                      color: Color(0x0A000000),
+                      blurRadius: 20,
+                    ),
+                  ],
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      FluentIcons.edit_16_regular,
+                      size: 16,
                       color: OColor.white,
                     ),
-                  ),
-                ],
+                    const SizedBox(width: OSpacing.xxs),
+                    OText(
+                      text: isRegistered ? 'Registered' : 'Register',
+                      style: OTextStyle.labelMedium.copyWith(
+                        color: OColor.white,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
           const SizedBox(width: OSpacing.s),
-          // I'm Interested button (secondary, outlined)
+          // I'm Interested button
           Expanded(
-            child: Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(OCornerRadius.m),
-                border: Border.all(color: OColor.gray300),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                   Icon(
-                    FluentIcons.heart_16_regular,
-                    size: 16,
-                    color: OColor.green600,
+            child: GestureDetector(
+              onTap: isActionLoading ? null : _toggleLikeOrInterest,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: isInterested ? OColor.green100 : Colors.transparent,
+                  borderRadius: BorderRadius.circular(OCornerRadius.m),
+                  border: Border.all(
+                    color: isInterested ? OColor.green600 : OColor.gray300,
                   ),
-                  const SizedBox(width: OSpacing.xxs),
-                  OText(
-                    text: "I'm Interested",
-                    style: OTextStyle.labelMedium.copyWith(
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      isInterested
+                          ? FluentIcons.heart_16_filled
+                          : FluentIcons.heart_16_regular,
+                      size: 16,
                       color: OColor.green600,
                     ),
-                  ),
-                ],
+                    const SizedBox(width: OSpacing.xxs),
+                    OText(
+                      text: isInterested ? "Interested" : "I'm Interested",
+                      style: OTextStyle.labelMedium.copyWith(
+                        color: OColor.green600,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -275,7 +383,7 @@ class _EventPopupContent extends StatelessWidget {
     return Wrap(
       spacing: OSpacing.m,
       runSpacing: OSpacing.xs,
-      children: event.categories.take(2).toList().asMap().entries.map((entry) {
+      children: event.categories.take(3).toList().asMap().entries.map((entry) {
         final color = tagColors[entry.key % tagColors.length];
         return Container(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -306,6 +414,7 @@ class _EventPopupContent extends StatelessWidget {
   /// Location and time info rows
   Widget _buildLocationAndTime() {
     final timeFormat = DateFormat('h:mm a');
+    final venueText = (event.venue != null && event.venue!.isNotEmpty) ? event.venue! : 'Campus';
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -313,7 +422,7 @@ class _EventPopupContent extends StatelessWidget {
         // Location
         Row(
           children: [
-             Icon(
+            Icon(
               FluentIcons.location_16_regular,
               size: 16,
               color: OColor.gray600,
@@ -321,7 +430,7 @@ class _EventPopupContent extends StatelessWidget {
             const SizedBox(width: OSpacing.xxs),
             Expanded(
               child: OText(
-                text: event.venue,
+                text: venueText,
                 style: OTextStyle.labelMedium.copyWith(color: OColor.gray600),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
@@ -333,7 +442,7 @@ class _EventPopupContent extends StatelessWidget {
         // Time
         Row(
           children: [
-             Icon(
+            Icon(
               FluentIcons.clock_16_regular,
               size: 16,
               color: OColor.gray600,
@@ -356,13 +465,6 @@ class _EventPopupContent extends StatelessWidget {
 
   /// Special Guests section with profile avatars
   Widget _buildSpecialGuests() {
-    // Placeholder guest data (would come from API in real implementation)
-    final guests = [
-      {'name': 'Guest 1', 'role': 'Organizer'},
-      {'name': 'Guest 2', 'role': 'Co-Organizer'},
-      {'name': 'Guest 3', 'role': 'Speaker'},
-    ];
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -374,12 +476,13 @@ class _EventPopupContent extends StatelessWidget {
         SingleChildScrollView(
           scrollDirection: Axis.horizontal,
           child: Row(
-            children: guests.map((guest) {
+            children: event.guest.map((g) {
               return Padding(
                 padding: const EdgeInsets.only(right: OSpacing.l),
                 child: _buildProfileChip(
-                  name: guest['name']!,
-                  subtitle: guest['role']!,
+                  name: g.name ?? 'Guest',
+                  subtitle: g.position ?? 'Speaker',
+                  photoUrl: g.photo,
                 ),
               );
             }).toList(),
@@ -412,6 +515,9 @@ class _EventPopupContent extends StatelessWidget {
 
   /// Posted By section with organizer avatar
   Widget _buildPostedBy() {
+    final clubTitle = event.clubOrg.isNotEmpty ? event.clubOrg : "Student Affairs";
+    final boardTitle = event.board.isNotEmpty ? event.board : "IIT Guwahati";
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -422,15 +528,14 @@ class _EventPopupContent extends StatelessWidget {
         const SizedBox(height: OSpacing.s),
         Row(
           children: [
-            // Organizer avatar
             Container(
               width: 48,
               height: 48,
-              decoration:  BoxDecoration(
+              decoration: BoxDecoration(
                 color: OColor.gray200,
                 shape: BoxShape.circle,
               ),
-              child:  Icon(
+              child: Icon(
                 FluentIcons.people_24_regular,
                 size: 24,
                 color: OColor.gray600,
@@ -442,7 +547,7 @@ class _EventPopupContent extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   OText(
-                    text: event.clubOrg,
+                    text: clubTitle,
                     style: OTextStyle.labelMedium.copyWith(
                       color: OColor.gray800,
                     ),
@@ -450,7 +555,7 @@ class _EventPopupContent extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                   ),
                   OText(
-                    text: event.board,
+                    text: boardTitle,
                     style: OTextStyle.bodyXSmall.copyWith(
                       color: OColor.gray600,
                     ),
@@ -464,14 +569,8 @@ class _EventPopupContent extends StatelessWidget {
     );
   }
 
-  /// POCs section with contact avatars
+  /// POCs section with contact avatars (horizontally scrollable)
   Widget _buildPOCs(BuildContext context) {
-    // Placeholder POC data (would come from API in real implementation)
-    final pocs = [
-      {'name': 'POC 1', 'role': 'Events Head'},
-      {'name': 'POC 2', 'role': 'Events Head'},
-    ];
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -480,16 +579,22 @@ class _EventPopupContent extends StatelessWidget {
           style: OTextStyle.labelMedium.copyWith(color: OColor.gray600),
         ),
         const SizedBox(height: OSpacing.s),
-        Wrap(
-          spacing: OSpacing.l,
-          runSpacing: OSpacing.s,
-          children: pocs.map((poc) {
-            return _buildProfileChip(
-              context: context,
-              name: poc['name']!,
-              subtitle: poc['role']!,
-            );
-          }).toList(),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: event.poc.map((poc) {
+              return Padding(
+                padding: const EdgeInsets.only(right: OSpacing.l),
+                child: _buildProfileChip(
+                  context: context,
+                  name: poc.name ?? 'POC',
+                  subtitle: poc.position ?? 'Events Head',
+                  number: poc.number,
+                  email: poc.email,
+                ),
+              );
+            }).toList(),
+          ),
         ),
       ],
     );
@@ -500,48 +605,64 @@ class _EventPopupContent extends StatelessWidget {
     BuildContext? context,
     required String name,
     required String subtitle,
+    String? photoUrl,
+    String? number,
+    String? email,
   }) {
     return GestureDetector(
       onTap: () {
         if (context != null) {
-          showPOCModal(context, name: name, subtitle: subtitle);
+          showPOCModal(
+            context,
+            name: name,
+            subtitle: subtitle,
+            number: number,
+            email: email,
+          );
         }
       },
       child: SizedBox(
-      width: 80,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            width: 48,
-            height: 48,
-            decoration:  BoxDecoration(
-              color: OColor.blue100,
-              shape: BoxShape.circle,
+        width: 80,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                color: OColor.blue100,
+                shape: BoxShape.circle,
+              ),
+              child: photoUrl != null && photoUrl.isNotEmpty
+                  ? EventNetworkImage.avatar(
+                      imageUrl: photoUrl,
+                      width: 48,
+                      height: 48,
+                    )
+                  : Icon(
+                      FluentIcons.person_24_regular,
+                      size: 32,
+                      color: OColor.blue500,
+                    ),
             ),
-            child:  Icon(
-              FluentIcons.person_24_regular,
-              size: 32,
-              color: OColor.blue500,
+            const SizedBox(height: OSpacing.xs),
+            OText(
+              text: name,
+              style: OTextStyle.labelMedium.copyWith(color: OColor.gray800),
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
-          ),
-          const SizedBox(height: OSpacing.xs),
-          OText(
-            text: name,
-            style: OTextStyle.labelMedium.copyWith(color: OColor.gray800),
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-          OText(
-            text: subtitle,
-            style: OTextStyle.bodyXSmall.copyWith(color: OColor.gray600),
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ],
+            OText(
+              text: subtitle,
+              style: OTextStyle.bodyXSmall.copyWith(color: OColor.gray600),
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
       ),
-    ));
+    );
   }
 }

--- a/lib/pages/events/widgets/event_search_bar.dart
+++ b/lib/pages/events/widgets/event_search_bar.dart
@@ -2,23 +2,32 @@ import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:onestop_ui/index.dart';
 
-/// Search bar widget matching the Figma design.
-///
-/// White rounded container with placeholder text and trailing search icon.
+/// Search bar widget matching the Figma design with full typing, debouncing, and clearing support.
 class EventSearchBar extends StatelessWidget {
   final String placeholder;
+  final TextEditingController? controller;
+  final FocusNode? focusNode;
+  final ValueChanged<String>? onChanged;
+  final VoidCallback? onClear;
   final VoidCallback? onTap;
+  final bool isLoading;
 
   const EventSearchBar({
     super.key,
-    this.placeholder = 'Placeholder Text',
+    this.placeholder = 'Search events by name, club or tags',
+    this.controller,
+    this.focusNode,
+    this.onChanged,
+    this.onClear,
     this.onTap,
+    this.isLoading = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
+    final isEditable = controller != null || onChanged != null;
+
+    return RepaintBoundary(
       child: Container(
         height: 48,
         padding: const EdgeInsets.symmetric(horizontal: OSpacing.s),
@@ -29,19 +38,75 @@ class EventSearchBar extends StatelessWidget {
         ),
         child: Row(
           children: [
-            Expanded(
-              child: OText(
-                text: placeholder,
-                style: OTextStyle.labelMedium.copyWith(
-                  color: OColor.gray600,
-                ),
-              ),
-            ),
             Icon(
               FluentIcons.search_24_regular,
-              size: 24,
-              color: OColor.gray600,
+              size: 20,
+              color: OColor.gray500,
             ),
+            const SizedBox(width: OSpacing.xs),
+            Expanded(
+              child:
+                  isEditable
+                      ? TextField(
+                        controller: controller,
+                        focusNode: focusNode,
+                        onChanged: onChanged,
+                        style: OTextStyle.labelMedium.copyWith(
+                          color: OColor.gray800,
+                        ),
+                        cursorColor: OColor.green600,
+                        decoration: InputDecoration(
+                          hintText: placeholder,
+                          hintStyle: OTextStyle.labelMedium.copyWith(
+                            color: OColor.gray400,
+                          ),
+                          border: InputBorder.none,
+                          isDense: true,
+                          contentPadding: EdgeInsets.zero,
+                        ),
+                      )
+                      : GestureDetector(
+                        onTap: onTap,
+                        behavior: HitTestBehavior.opaque,
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: OText(
+                            text: placeholder,
+                            style: OTextStyle.labelMedium.copyWith(
+                              color: OColor.gray400,
+                            ),
+                          ),
+                        ),
+                      ),
+            ),
+            if (isLoading)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                child: SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(OColor.green600),
+                  ),
+                ),
+              )
+            else if (controller != null && controller!.text.isNotEmpty)
+              GestureDetector(
+                onTap: () {
+                  controller?.clear();
+                  onClear?.call();
+                },
+                behavior: HitTestBehavior.opaque,
+                child: Padding(
+                  padding: const EdgeInsets.all(4.0),
+                  child: Icon(
+                    FluentIcons.dismiss_circle_24_filled,
+                    size: 18,
+                    color: OColor.gray400,
+                  ),
+                ),
+              ),
           ],
         ),
       ),

--- a/lib/pages/events/widgets/events_compact_card.dart
+++ b/lib/pages/events/widgets/events_compact_card.dart
@@ -1,12 +1,13 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:onestop_dev/models/event_scheduler/event_model.dart';
+import 'package:onestop_dev/pages/events/utils/event_formatters.dart';
+import 'package:onestop_dev/pages/events/widgets/components/event_network_image.dart';
 import 'package:onestop_ui/index.dart';
 
 /// Compact event card used in the "Recently Attended" horizontal scroll.
 ///
-/// Shows avatar, event title, optional tags, and an optional
-/// "Submit a Feedback" button with a trailing chevron.
+/// Composed of [EventNetworkImage.avatar], title, and "Submit a Feedback" button.
 class EventsCompactCard extends StatelessWidget {
   final EventModel event;
   final bool showFeedbackButton;
@@ -23,6 +24,9 @@ class EventsCompactCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final title = EventFormatters.sanitizeText(event.title);
+    final imageUrl = event.compressedImageUrl ?? event.imageUrl;
+
     return GestureDetector(
       onTap: onTap,
       child: Container(
@@ -41,8 +45,12 @@ class EventsCompactCard extends StatelessWidget {
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                // Avatar
-                _buildAvatar(),
+                // Avatar with progressive shimmer & caching
+                EventNetworkImage.avatar(
+                  imageUrl: imageUrl,
+                  width: 48,
+                  height: 48,
+                ),
                 const SizedBox(width: OSpacing.s),
                 // Content
                 Expanded(
@@ -51,7 +59,7 @@ class EventsCompactCard extends StatelessWidget {
                     children: [
                       // Title
                       OText(
-                        text: event.title,
+                        text: title,
                         style: OTextStyle.bodyMedium.copyWith(
                           color: OColor.gray800,
                         ),
@@ -85,69 +93,38 @@ class EventsCompactCard extends StatelessWidget {
                   const SizedBox(height: OSpacing.xs),
                   GestureDetector(
                     onTap: onFeedbackTap,
+                    behavior: HitTestBehavior.opaque,
                     child: Container(
-                        width: double.infinity,
-                        height: 40,
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(OCornerRadius.m),
-                          border: Border.all(color: OColor.gray300),
-                        ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            OText(
-                              text: 'Submit a Feedback',
-                              style: OTextStyle.labelMedium.copyWith(
-                                color: OColor.green600,
-                              ),
-                            ),
-                            const SizedBox(width: OSpacing.xxs),
-                            Icon(
-                              FluentIcons.chat_24_regular,
-                              size: 16,
+                      width: double.infinity,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(OCornerRadius.m),
+                        border: Border.all(color: OColor.gray300),
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          OText(
+                            text: 'Submit a Feedback',
+                            style: OTextStyle.labelMedium.copyWith(
                               color: OColor.green600,
                             ),
-                          ],
-                        ),
+                          ),
+                          const SizedBox(width: OSpacing.xxs),
+                          Icon(
+                            FluentIcons.chat_24_regular,
+                            size: 16,
+                            color: OColor.green600,
+                          ),
+                        ],
                       ),
                     ),
-                  
+                  ),
                 ],
               ),
             ],
           ],
         ),
-      ),
-    );
-  }
-
-  Widget _buildAvatar() {
-    if (event.compressedImageUrl != null) {
-      return ClipOval(
-        child: Image.network(
-          event.compressedImageUrl!,
-          width: 48,
-          height: 48,
-          fit: BoxFit.cover,
-          errorBuilder: (_, __, ___) => _placeholderAvatar(),
-        ),
-      );
-    }
-    return _placeholderAvatar();
-  }
-
-  Widget _placeholderAvatar() {
-    return Container(
-      width: 48,
-      height: 48,
-      decoration: BoxDecoration(
-        color: OColor.gray200,
-        shape: BoxShape.circle,
-      ),
-      child: Icon(
-        FluentIcons.calendar_24_regular,
-        size: 24,
-        color: OColor.gray600,
       ),
     );
   }

--- a/lib/pages/events/widgets/events_home_shimmer.dart
+++ b/lib/pages/events/widgets/events_home_shimmer.dart
@@ -1,0 +1,357 @@
+import 'package:flutter/material.dart';
+import 'package:onestop_ui/index.dart';
+import 'package:shimmer/shimmer.dart';
+
+/// Skeletal loading shimmer for the Events Homepage.
+class EventsHomeShimmer extends StatelessWidget {
+  const EventsHomeShimmer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // 1. Happening Today Shimmer
+        _buildSectionHeaderShimmer(width: 140),
+        const SizedBox(height: OSpacing.s),
+        SizedBox(
+          height: 96,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+            itemCount: 3,
+            separatorBuilder: (_, _) => const SizedBox(width: OSpacing.s),
+            itemBuilder: (_, _) => const EventSmallCardShimmer(),
+          ),
+        ),
+        const SizedBox(height: OSpacing.l),
+
+        // 2. Trending Events Shimmer
+        _buildSectionHeaderShimmer(width: 130),
+        const SizedBox(height: OSpacing.s),
+        SizedBox(
+          height: 290,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+            itemCount: 2,
+            separatorBuilder: (_, _) => const SizedBox(width: OSpacing.s),
+            itemBuilder: (_, _) => const EventMediumCardShimmer(),
+          ),
+        ),
+        const SizedBox(height: OSpacing.l),
+
+        // 3. Your Interests Large Cards Shimmer
+        _buildSectionHeaderShimmer(width: 120),
+        const SizedBox(height: OSpacing.s),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+          child: Column(
+            children: const [
+              EventLargeCardShimmer(),
+              SizedBox(height: OSpacing.s),
+              EventLargeCardShimmer(),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSectionHeaderShimmer({required double width}) {
+    return Shimmer.fromColors(
+      baseColor: OColor.gray200,
+      highlightColor: OColor.gray100,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: OSpacing.m),
+        child: Row(
+          children: [
+            Container(
+              width: 20,
+              height: 20,
+              decoration: BoxDecoration(
+                color: OColor.white,
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ),
+            const SizedBox(width: OSpacing.xs),
+            Container(
+              width: width,
+              height: 18,
+              decoration: BoxDecoration(
+                color: OColor.white,
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Standalone shimmer matching [EventListingSmallCard].
+class EventSmallCardShimmer extends StatelessWidget {
+  const EventSmallCardShimmer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 358,
+      padding: const EdgeInsets.all(OSpacing.s),
+      decoration: BoxDecoration(
+        color: OColor.white,
+        borderRadius: BorderRadius.circular(OCornerRadius.m),
+        border: Border.all(color: OColor.gray200),
+      ),
+      child: Shimmer.fromColors(
+        baseColor: OColor.gray200,
+        highlightColor: OColor.gray100,
+        child: Row(
+          children: [
+            Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                color: OColor.gray200,
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: OSpacing.s),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Container(
+                    width: double.infinity,
+                    height: 14,
+                    decoration: BoxDecoration(
+                      color: OColor.gray200,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Container(
+                    width: 80,
+                    height: 10,
+                    decoration: BoxDecoration(
+                      color: OColor.gray200,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Container(
+                    width: 60,
+                    height: 10,
+                    decoration: BoxDecoration(
+                      color: OColor.gray200,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Standalone shimmer matching [EventListingMediumCard].
+class EventMediumCardShimmer extends StatelessWidget {
+  const EventMediumCardShimmer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 210,
+      decoration: BoxDecoration(
+        color: OColor.white,
+        borderRadius: BorderRadius.circular(OCornerRadius.m),
+        border: Border.all(color: OColor.gray200),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Shimmer.fromColors(
+        baseColor: OColor.gray200,
+        highlightColor: OColor.gray100,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Banner image shimmer
+            AspectRatio(
+              aspectRatio: 16 / 9,
+              child: Container(
+                color: OColor.gray200,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(OSpacing.s),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 160,
+                    height: 14,
+                    decoration: BoxDecoration(
+                      color: OColor.gray200,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Container(
+                    width: 100,
+                    height: 10,
+                    decoration: BoxDecoration(
+                      color: OColor.gray200,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Container(
+                        width: 50,
+                        height: 16,
+                        decoration: BoxDecoration(
+                          color: OColor.gray200,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      Container(
+                        width: 50,
+                        height: 16,
+                        decoration: BoxDecoration(
+                          color: OColor.gray200,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Standalone shimmer matching [EventListingLargeCard].
+class EventLargeCardShimmer extends StatelessWidget {
+  const EventLargeCardShimmer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: OColor.white,
+        borderRadius: BorderRadius.circular(OCornerRadius.m),
+        border: Border.all(color: OColor.gray200),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Shimmer.fromColors(
+        baseColor: OColor.gray200,
+        highlightColor: OColor.gray100,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Image banner
+            AspectRatio(
+              aspectRatio: 358 / 201,
+              child: Container(
+                color: OColor.gray200,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(OSpacing.s),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Title
+                  Container(
+                    width: 240,
+                    height: 18,
+                    decoration: BoxDecoration(
+                      color: OColor.gray200,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                  const SizedBox(height: OSpacing.s),
+                  // Tags
+                  Row(
+                    children: [
+                      Container(
+                        width: 60,
+                        height: 20,
+                        decoration: BoxDecoration(
+                          color: OColor.gray200,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      Container(
+                        width: 70,
+                        height: 20,
+                        decoration: BoxDecoration(
+                          color: OColor.gray200,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: OSpacing.s),
+                  // Location / Date
+                  Container(
+                    width: 180,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      color: OColor.gray200,
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                  ),
+                  const SizedBox(height: OSpacing.s),
+                  // Divider
+                  Container(
+                    width: double.infinity,
+                    height: 1,
+                    color: OColor.gray200,
+                  ),
+                  const SizedBox(height: OSpacing.s),
+                  // Footer
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Container(
+                        width: 100,
+                        height: 14,
+                        decoration: BoxDecoration(
+                          color: OColor.gray200,
+                          borderRadius: BorderRadius.circular(3),
+                        ),
+                      ),
+                      Container(
+                        width: 80,
+                        height: 32,
+                        decoration: BoxDecoration(
+                          color: OColor.gray200,
+                          borderRadius: BorderRadius.circular(OCornerRadius.s),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/events/widgets/poc_modal.dart
+++ b/lib/pages/events/widgets/poc_modal.dart
@@ -1,14 +1,26 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:onestop_ui/index.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// Shows the POC modal as a bottom sheet.
-void showPOCModal(BuildContext context, {required String name, required String subtitle}) {
+void showPOCModal(
+  BuildContext context, {
+  required String name,
+  required String subtitle,
+  String? number,
+  String? email,
+}) {
   showModalBottomSheet(
     context: context,
     backgroundColor: Colors.transparent,
     builder: (_) {
-      return _POCModalContent(name: name, subtitle: subtitle);
+      return _POCModalContent(
+        name: name,
+        subtitle: subtitle,
+        number: number,
+        email: email,
+      );
     },
   );
 }
@@ -16,11 +28,42 @@ void showPOCModal(BuildContext context, {required String name, required String s
 class _POCModalContent extends StatelessWidget {
   final String name;
   final String subtitle;
+  final String? number;
+  final String? email;
 
-  const _POCModalContent({required this.name, required this.subtitle});
+  const _POCModalContent({
+    required this.name,
+    required this.subtitle,
+    this.number,
+    this.email,
+  });
+
+  Future<void> _launchCall(String phone) async {
+    final uri = Uri.parse('tel:$phone');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
+
+  Future<void> _launchSms(String phone) async {
+    final uri = Uri.parse('sms:$phone');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
+
+  Future<void> _launchEmail(String mail) async {
+    final uri = Uri.parse('mailto:$mail');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
+    final displayNumber = number ?? '+911234567890';
+    final displayEmail = email ?? 'contact@iitg.ac.in';
+
     return Container(
       decoration: BoxDecoration(
         color: OColor.white,
@@ -94,47 +137,69 @@ class _POCModalContent extends StatelessWidget {
           const SizedBox(height: OSpacing.l),
 
           // Contact info rows
-          Row(
-            children: [
-              Icon(FluentIcons.call_24_regular, size: 16, color: OColor.gray500),
-              const SizedBox(width: OSpacing.xs),
-              Expanded(
-                child: OText(
-                  text: "+91123456789", // Mock data
-                  style: OTextStyle.labelSmall.copyWith(color: OColor.gray600),
-                ),
+          if (number != null && number!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: OSpacing.xs),
+              child: Row(
+                children: [
+                  Icon(FluentIcons.call_24_regular, size: 16, color: OColor.gray500),
+                  const SizedBox(width: OSpacing.xs),
+                  Expanded(
+                    child: OText(
+                      text: displayNumber,
+                      style: OTextStyle.labelSmall.copyWith(color: OColor.gray600),
+                    ),
+                  ),
+                ],
               ),
-            ],
-          ),
-          const SizedBox(height: OSpacing.xs),
-          Row(
-            children: [
-              Icon(FluentIcons.mail_24_regular, size: 16, color: OColor.gray500),
-              const SizedBox(width: OSpacing.xs),
-              Expanded(
-                child: OText(
-                  text: "adoiisi@iitg.ac.in", // Mock data
-                  style: OTextStyle.labelSmall.copyWith(color: OColor.gray600),
-                ),
+            ),
+          if (email != null && email!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: OSpacing.xs),
+              child: Row(
+                children: [
+                  Icon(FluentIcons.mail_24_regular, size: 16, color: OColor.gray500),
+                  const SizedBox(width: OSpacing.xs),
+                  Expanded(
+                    child: OText(
+                      text: displayEmail,
+                      style: OTextStyle.labelSmall.copyWith(color: OColor.gray600),
+                    ),
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
           const SizedBox(height: OSpacing.l),
 
           // Action buttons: Call / Text / Mail
           Row(
             children: [
-              Expanded(
-                child: _buildActionButton(icon: FluentIcons.call_16_regular, label: 'Call', onTap: () {}),
-              ),
-              const SizedBox(width: OSpacing.xs),
-              Expanded(
-                child: _buildActionButton(icon: FluentIcons.chat_16_regular, label: 'Text', onTap: () {}),
-              ),
-              const SizedBox(width: OSpacing.xs),
-              Expanded(
-                child: _buildActionButton(icon: FluentIcons.mail_16_regular, label: 'Mail', onTap: () {}),
-              ),
+              if (number != null && number!.isNotEmpty) ...[
+                Expanded(
+                  child: _buildActionButton(
+                    icon: FluentIcons.call_16_regular,
+                    label: 'Call',
+                    onTap: () => _launchCall(displayNumber),
+                  ),
+                ),
+                const SizedBox(width: OSpacing.xs),
+                Expanded(
+                  child: _buildActionButton(
+                    icon: FluentIcons.chat_16_regular,
+                    label: 'Text',
+                    onTap: () => _launchSms(displayNumber),
+                  ),
+                ),
+                const SizedBox(width: OSpacing.xs),
+              ],
+              if (email != null && email!.isNotEmpty)
+                Expanded(
+                  child: _buildActionButton(
+                    icon: FluentIcons.mail_16_regular,
+                    label: 'Mail',
+                    onTap: () => _launchEmail(displayEmail),
+                  ),
+                ),
             ],
           ),
           // Add safe area for bottom

--- a/lib/pages/events/widgets/section_header.dart
+++ b/lib/pages/events/widgets/section_header.dart
@@ -1,4 +1,3 @@
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:onestop_ui/index.dart';
 

--- a/lib/pages/events_feed/event_description.dart
+++ b/lib/pages/events_feed/event_description.dart
@@ -6,6 +6,7 @@ import 'package:onestop_dev/globals/my_colors.dart';
 import 'package:onestop_dev/globals/my_fonts.dart';
 import 'package:onestop_dev/main.dart';
 import 'package:onestop_dev/models/event_scheduler/event_model.dart';
+import 'package:onestop_dev/pages/events/widgets/components/event_network_image.dart';
 import 'package:onestop_dev/pages/events_feed/event_form_screen.dart';
 import 'package:onestop_dev/repository/events_api_repository.dart';
 
@@ -118,12 +119,12 @@ class _EventDetailsScreenState extends State<EventDetailsScreen> {
                         ),
                       ],
                     ),
-                    child: ClipRRect(
+                    child: EventNetworkImage(
+                      imageUrl: widget.event.imageUrl,
+                      width: double.infinity,
+                      height: 400,
                       borderRadius: BorderRadius.circular(10.0),
-                      child: Image.network(
-                        widget.event.imageUrl ?? "",
-                        fit: BoxFit.cover,
-                      ),
+                      fit: BoxFit.cover,
                     ),
                   ),
                   if (widget.isAdmin)
@@ -197,7 +198,7 @@ class _EventDetailsScreenState extends State<EventDetailsScreen> {
                             ),
                             Flexible(
                               child: Text(
-                                widget.event.venue,
+                                widget.event.venue ?? '',
                                 style: MyFonts.w500.copyWith(color: kWhite),
                                 overflow: TextOverflow.ellipsis,
                               ),
@@ -260,24 +261,12 @@ class _EventDetailsScreenState extends State<EventDetailsScreen> {
                   )
                 ],
               ),
-              /*Column(
-                children: [
-                  _buildEventDetail("Date",
-                      "${widget.event.startDateTime.day}/${widget.event.startDateTime.month}/${widget.event.startDateTime.year}"),
-                  const SizedBox(width: 5.0),
-                  _buildEventDetail("Time",
-                      "${widget.event.startDateTime.hour}:${widget.event.startDateTime.minute} - ${(widget.event.startDateTime.add(const Duration(hours: 1)).hour).toString().padLeft(2, '0')}:${widget.event.startDateTime.minute.toString().padLeft(2, '0')}"),
-                ],
-              ),
-              _buildEventDetail("Venue", widget.event.venue),
-              //_buildEventDetail("Contact Details", widget.event.contactNumber),
-              _buildEventDetail("Conducted by", widget.event.clubOrg),*/
               const SizedBox(height: 10.0),
               // Event Description
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
                 child: Text(
-                  widget.event.description,
+                  widget.event.description ?? '',
                   style: MyFonts.w500.copyWith(color: kWhite, fontSize: 15),
                 ),
               ),

--- a/lib/pages/events_feed/event_form_screen.dart
+++ b/lib/pages/events_feed/event_form_screen.dart
@@ -50,17 +50,20 @@ class _EventFormScreenState extends State<EventFormScreen> {
     super.initState();
 
     Admin? admin = context.read<EventsStore>().admin;
-    final userClubs = admin?.getUserClubs(LoginStore.userData['outlookEmail']!);
-    selectedBoard = userClubs?.first.name;
+    final email = LoginStore.userData['outlookEmail'] ?? '';
+    final userClubs = admin?.getUserClubs(email);
+    selectedBoard = (userClubs != null && userClubs.isNotEmpty) ? userClubs.first.name : 'Technical Board';
 
-    clubs = userClubs!.first.members.clubsOrgs;
+    clubs = (userClubs != null && userClubs.isNotEmpty)
+        ? userClubs.first.members.clubsOrgs
+        : ["Coding Club", "Robotics Club", "Aeromodelling Club", "Electronics Club"];
     selectedClub = clubs.first;
     log("selectedBoard== $selectedBoard");
     if (widget.event != null) {
       final event = widget.event!;
       titleController.text = event.title;
-      venueController.text = event.venue;
-      descriptionController.text = event.description;
+      venueController.text = event.venue ?? '';
+      descriptionController.text = event.description ?? '';
 
       selectedDate = event.startDateTime;
       selectedStartTime = TimeOfDay.fromDateTime(event.startDateTime);
@@ -552,20 +555,6 @@ class _EventFormScreenState extends State<EventFormScreen> {
   // Submit Form Method
   Future<void> _submitForm() async {
     final nav = Navigator.of(context);
-    var fileName = uploadedFilePath!.split('/').last;
-    Map<String, dynamic> data = {};
-    data['file'] =
-        await MultipartFile.fromFile(uploadedFilePath!, filename: fileName);
-    data['title'] = titleController.text;
-    data['description'] = descriptionController.text;
-    data['club_org'] = selectedClub;
-    data['startDateTime'] = _formatDateTime(selectedDate!, selectedStartTime!);
-    data['endDateTime'] = _formatDateTime(selectedDate!, selectedEndTime!);
-    data['venue'] = venueController.text;
-    data['categories'] = <String>["$selectedBoard", "All"];
-    data['board'] = selectedBoard;
-
-    Map<String, dynamic> res = {};
 
     // Show the loading dialog
     showDialog(
@@ -593,6 +582,21 @@ class _EventFormScreenState extends State<EventFormScreen> {
       },
     );
 
+    var fileName = uploadedFilePath!.split('/').last;
+    Map<String, dynamic> data = {};
+    data['file'] =
+        await MultipartFile.fromFile(uploadedFilePath!, filename: fileName);
+    data['title'] = titleController.text;
+    data['description'] = descriptionController.text;
+    data['club_org'] = selectedClub;
+    data['startDateTime'] = _formatDateTime(selectedDate!, selectedStartTime!);
+    data['endDateTime'] = _formatDateTime(selectedDate!, selectedEndTime!);
+    data['venue'] = venueController.text;
+    data['categories'] = <String>["$selectedBoard", "All"];
+    data['board'] = selectedBoard;
+
+    Map<String, dynamic> res = {};
+
     try {
       Logger().i("Uploading to server");
       res = await EventsAPIRepository().postEvent(data);
@@ -601,7 +605,7 @@ class _EventFormScreenState extends State<EventFormScreen> {
     }
     nav.pop();
 
-    if (res['saved_successfully']) {
+    if (res['saved_successfully'] == true || res['success'] == true) {
       showSnackBar('Event submitted successfully!');
       nav.pop();
     } else {
@@ -611,19 +615,6 @@ class _EventFormScreenState extends State<EventFormScreen> {
 
   Future<void> _editForm() async {
     final nav = Navigator.of(context);
-
-    Map<String, dynamic> data = {};
-    data['file'] = uploadedFilePath != null
-        ? (await MultipartFile.fromFile(uploadedFilePath!))
-        : null;
-    data['title'] = titleController.text;
-    data['description'] = descriptionController.text;
-    data['club_org'] = selectedClub;
-    data['startDateTime'] = _formatDateTime(selectedDate!, selectedStartTime!);
-    data['endDateTime'] = _formatDateTime(selectedDate!, selectedEndTime!);
-    data['venue'] = venueController.text;
-    data['categories'] = <String>["$selectedBoard", "All"];
-    data['board'] = selectedBoard;
 
     showDialog(
       context: context,
@@ -649,6 +640,19 @@ class _EventFormScreenState extends State<EventFormScreen> {
         );
       },
     );
+
+    Map<String, dynamic> data = {};
+    data['file'] = uploadedFilePath != null
+        ? (await MultipartFile.fromFile(uploadedFilePath!))
+        : null;
+    data['title'] = titleController.text;
+    data['description'] = descriptionController.text;
+    data['club_org'] = selectedClub;
+    data['startDateTime'] = _formatDateTime(selectedDate!, selectedStartTime!);
+    data['endDateTime'] = _formatDateTime(selectedDate!, selectedEndTime!);
+    data['venue'] = venueController.text;
+    data['categories'] = <String>["$selectedBoard", "All"];
+    data['board'] = selectedBoard;
 
     try {
       await EventsAPIRepository().putEvent(widget.event!.id, data);

--- a/lib/pages/events_feed/event_tile.dart
+++ b/lib/pages/events_feed/event_tile.dart
@@ -55,7 +55,7 @@ class EventTile extends StatelessWidget {
                           ),
                           const SizedBox(height: 5),
                           Text(
-                            model.description,
+                            model.description ?? '',
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
                             style: MyFonts.w500.copyWith(color: kWhite3),
@@ -90,7 +90,7 @@ class EventTile extends StatelessWidget {
                               const SizedBox(width: 6),
                               Expanded(
                                 child: Text(
-                                  model.venue,
+                                  model.venue ?? '',
                                   style: MyFonts.w500.copyWith(color: kWhite3),
                                   overflow: TextOverflow.ellipsis,
                                 ),

--- a/lib/pages/events_feed/events_appbar.dart
+++ b/lib/pages/events_feed/events_appbar.dart
@@ -38,10 +38,13 @@ class _EventsScreenWrapperState extends State<EventsScreenWrapper> {
 
   Future<bool> _checkIfUserIsAdminLogic() async {
     try {
-      final email = LoginStore.userData['outlookEmail'];
+      final email = LoginStore.userData['outlookEmail']?.toString() ?? '';
       final admin = await EventsAPIRepository().getAdmins();
       if (admin == null) return false;
-      bool isAdmin = admin.getUserClubs(email).isNotEmpty;
+      if (mounted) {
+        context.read<EventsStore>().setAdmin(admin);
+      }
+      bool isAdmin = email.isNotEmpty && admin.getUserClubs(email).isNotEmpty;
       return isAdmin;
     } catch (e) {
       log("Error checking admin status: $e");

--- a/lib/pages/events_feed/events_screen.dart
+++ b/lib/pages/events_feed/events_screen.dart
@@ -25,55 +25,55 @@ class _EventsScreenState extends State<EventsScreen> with TickerProviderStateMix
 
   final Map<String, PagingController<int, EventModel>> _pagingControllers = {
     'Saved': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Saved'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Saved', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Sports': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Sports'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Sports', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'All': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('All'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('All', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Technical': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Technical'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Technical', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Cultural': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Cultural'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Cultural', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Academic': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Academic'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Academic', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Welfare': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Welfare'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Welfare', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'SWC': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('SWC'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('SWC', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Miscellaneous': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Miscellaneous'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Miscellaneous', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },

--- a/lib/pages/events_feed/events_screen_admin.dart
+++ b/lib/pages/events_feed/events_screen_admin.dart
@@ -26,58 +26,58 @@ class _EventsScreen1State extends State<EventsScreen1> with TickerProviderStateM
         admin ??= await EventsAPIRepository().getAdmins();
         if (admin == null) return [];
         EventsStore().setAdmin(admin);
-        final userClubs = admin.getUserClubs(LoginStore.userData['outlookEmail']!);
-        final yourClub = userClubs.first.name;
-        return EventsAPIRepository().getEventPage(yourClub);
+        final userClubs = admin.getUserClubs(LoginStore.userData['outlookEmail'] ?? '');
+        final yourClub = userClubs.isNotEmpty ? userClubs.first.name : 'Technical Board';
+        return EventsAPIRepository().getEventPage(yourClub, page: pageKey);
       },
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'All': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('All'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('All', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Academic': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Academic'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Academic', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Sports': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Sports'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Sports', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Technical': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Technical'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Technical', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Cultural': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Cultural'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Cultural', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Welfare': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Welfare'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Welfare', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'SWC': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('SWC'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('SWC', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },
     ),
     'Miscellaneous': PagingController(
-      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Miscellaneous'),
+      fetchPage: (pageKey) => EventsAPIRepository().getEventPage('Miscellaneous', page: pageKey),
       getNextPageKey: (state) {
         return state.lastPageIsEmpty ? null : state.nextIntPageKey;
       },

--- a/lib/pages/events_feed/widgets/save_button.dart
+++ b/lib/pages/events_feed/widgets/save_button.dart
@@ -37,6 +37,7 @@ class _SaveButtonState extends State<SaveButton> {
         builder: (context, snapshot) {
           if (snapshot.hasData) {
             bool isAlreadySaved = snapshot.data as bool;
+            final eventsStore = context.read<EventsStore>();
             if (isAlreadySaved) {
               return IconButton(
                   onPressed: () async {
@@ -48,8 +49,7 @@ class _SaveButtonState extends State<SaveButton> {
                             EventModel.fromJson(e as Map<String, dynamic>))
                         .toList();
                     savedEvents.removeWhere((e) => e.id == widget.event.id);
-                    if (!mounted) return;
-                    context.read<EventsStore>().setSavedEvents(savedEvents);
+                    eventsStore.setSavedEvents(savedEvents);
                     if (savedEvents.isEmpty) {
                       await LocalStorage.instance
                           .deleteRecord(DatabaseRecords.savedEvents);
@@ -59,7 +59,7 @@ class _SaveButtonState extends State<SaveButton> {
                       await LocalStorage.instance.storeListRecord(
                           savedList, DatabaseRecords.savedEvents);
                     }
-                    setState(() {});
+                    if (mounted) setState(() {});
                   },
                   icon: const Icon(
                     Icons.bookmark_rounded,
@@ -82,10 +82,9 @@ class _SaveButtonState extends State<SaveButton> {
                       await LocalStorage.instance.storeListRecord(
                           savedList, DatabaseRecords.savedEvents);
                     }
-                    if (!mounted) return;
-                    context.read<EventsStore>().setSavedEvents(
+                    eventsStore.setSavedEvents(
                         savedList.map((e) => EventModel.fromJson(e)).toList());
-                    setState(() {});
+                    if (mounted) setState(() {});
                   },
                   icon: const Icon(
                     Icons.bookmark_border,

--- a/lib/pages/events_feed/your_event_list_view.dart
+++ b/lib/pages/events_feed/your_event_list_view.dart
@@ -27,8 +27,9 @@ class _YourEventListViewState extends State<YourEventListView> {
   void initState() {
     super.initState();
     Admin? admin = context.read<EventsStore>().admin;
-    final userClubs = admin?.getUserClubs(LoginStore.userData['outlookEmail']!);
-    yourClub = userClubs?.first.name;
+    final email = LoginStore.userData['outlookEmail'] ?? '';
+    final userClubs = admin?.getUserClubs(email);
+    yourClub = (userClubs != null && userClubs.isNotEmpty) ? userClubs.first.name : 'Technical Board';
   }
 
   @override

--- a/lib/pages/home/library_helper.dart
+++ b/lib/pages/home/library_helper.dart
@@ -43,8 +43,8 @@ Future<void> checkLibrarySlot({
         final isBanned = data['isBanned'] ?? data['banend'] ?? false;
         final message = data['message'] as String?;
         final currentRouteName = ModalRoute.of(context)?.settings.name;
-        final isOnLibraryTokenScreen =
-            currentRouteName == LibraryTokenScreen.id;
+        final isOnLibraryTokenScreen = 
+          currentRouteName == LibraryTokenScreen.id;
 
         final isBagPresent = slotId != null && message != null;
         context.read<CommonStore>().setBagInLibrary(isBagPresent);
@@ -92,18 +92,18 @@ Future<void> checkLibrarySlot({
                         onTap: () {
                           Navigator.of(dialogContext).pop();
                           setDialogShowing(false);
-                          parentNavigator.pushNamed(LibraryTokenScreen.id).then(
-                            (_) {
-                              if (!isMounted()) return;
-                              checkLibrarySlot(
-                                context: context,
-                                isMounted: isMounted,
-                                onStateUpdate: onStateUpdate,
-                                isBannedDialogShowing: false,
-                                setDialogShowing: setDialogShowing,
-                              );
-                            },
-                          );
+                          parentNavigator
+                          .pushNamed(LibraryTokenScreen.id)
+                          .then((_) {
+                            if (!isMounted()) return;
+                            checkLibrarySlot(
+                              context: context,
+                              isMounted: isMounted,
+                              onStateUpdate: onStateUpdate,
+                              isBannedDialogShowing: false,
+                              setDialogShowing: setDialogShowing,
+                            );
+                          });
                         },
                         child: Container(
                           width: double.infinity,

--- a/lib/repository/events_api_repository.dart
+++ b/lib/repository/events_api_repository.dart
@@ -1,8 +1,12 @@
+import 'dart:developer';
+
 import 'package:dio/dio.dart';
 import 'package:onestop_dev/functions/utility/show_snackbar.dart';
 import 'package:onestop_dev/globals/endpoints.dart';
 import 'package:onestop_dev/models/event_scheduler/admin_model.dart';
+import 'package:onestop_dev/models/event_scheduler/club_model.dart';
 import 'package:onestop_dev/models/event_scheduler/event_model.dart';
+import 'package:onestop_dev/models/event_scheduler/student_event_interaction_model.dart';
 import 'package:onestop_dev/stores/login_store.dart';
 import 'package:onestop_kit/onestop_kit.dart';
 
@@ -18,46 +22,372 @@ class EventsAPIRepository extends OneStopApi {
           },
         );
 
-  Future<Admin?> getAdmins() async {
-    var response = await serverDio.get(Endpoints.getEventAdmin);
-    var json = response.data;
+  Future<Map<String, dynamic>> createClub(ClubModel club) async {
+    final response = await serverDio.post(
+      '/api/v1/clubs/create-club',
+      data: club.toJson(),
+    );
+    return Map<String, dynamic>.from(response.data);
+  }
 
-    if (json != null && json is List) {
-      final data = json[0];
-      Admin admin = Admin.fromJson(data);
-      return admin;
-    } else {
+  Future<List<ClubModel>> getAllClubs({String? category, String? search}) async {
+    try {
+      final queryParameters = <String, dynamic>{};
+      if (category != null && category.isNotEmpty && category != 'All') {
+        queryParameters['category'] = category;
+      }
+      if (search != null && search.isNotEmpty) {
+        queryParameters['search'] = search;
+      }
+
+      final response = await serverDio.get(
+        '/api/v1/clubs/get-all',
+        queryParameters: queryParameters.isNotEmpty ? queryParameters : null,
+      );
+      final json = response.data;
+      if (json['success'] == true && json['data'] is List) {
+        return (json['data'] as List<dynamic>)
+            .map((e) => ClubModel.fromJson(e as Map<String, dynamic>))
+            .toList();
+      }
+      return [];
+    } catch (e) {
+      log('Error fetching clubs: $e');
+      return [];
+    }
+  }
+
+  Future<ClubModel?> getClubDetails(String clubId) async {
+    try {
+      final response = await serverDio.get('/api/v1/clubs/$clubId');
+      final json = response.data;
+      if (json['success'] == true && json['data'] is Map) {
+        return ClubModel.fromJson(json['data'] as Map<String, dynamic>);
+      }
+      return null;
+    } catch (e) {
+      log('Error fetching club details: $e');
       return null;
     }
   }
 
-  Future<Map<String, dynamic>> postEvent(Map<String, dynamic> data) async {
-    var res = await serverDio.post(serverBaseUrl, data: FormData.fromMap(data));
-    return res.data;
+  Future<Map<String, dynamic>> createEvent(
+    EventModel event, {
+    required String email,
+  }) async {
+    final response = await serverDio.post(
+      '/api/v1/events/create-event',
+      data: event.toJson(),
+      options: Options(headers: {'x-email': email}),
+    );
+    return Map<String, dynamic>.from(response.data);
   }
 
-  Future<Map<String, dynamic>> deleteEvent(String id) async {
-    var res = await serverDio.delete('/$id');
-    return res.data;
+  Future<Map<String, dynamic>> postEvent(
+    Map<String, dynamic> data, {
+    String? email,
+  }) async {
+    final userEmail = email ?? LoginStore.userData['outlookEmail'] ?? '';
+    final response = await serverDio.post(
+      '/api/v1/events/create-event',
+      data: data,
+      options: Options(headers: {'x-email': userEmail}),
+    );
+    return Map<String, dynamic>.from(response.data);
+  }
+
+  Future<Map<String, dynamic>> updateEvent(
+    String eventId,
+    EventModel event, {
+    required String email,
+  }) async {
+    final response = await serverDio.put(
+      '/api/v1/events/update-event/$eventId',
+      data: event.toJson(),
+      options: Options(headers: {'x-email': email}),
+    );
+    return Map<String, dynamic>.from(response.data);
   }
 
   Future<Map<String, dynamic>> putEvent(
-      String id, Map<String, dynamic> data) async {
-    var res = await serverDio.put('/$id', data: FormData.fromMap(data));
-    return res.data;
+    String eventId,
+    Map<String, dynamic> data, {
+    String? email,
+  }) async {
+    final userEmail = email ?? LoginStore.userData['outlookEmail'] ?? '';
+    final response = await serverDio.put(
+      '/api/v1/events/update-event/$eventId',
+      data: data,
+      options: Options(headers: {'x-email': userEmail}),
+    );
+    return Map<String, dynamic>.from(response.data);
   }
 
-  Future<List<EventModel>> getEventPage(String category) async {
-    var response = await serverDio.get(Endpoints.eventCategories);
-    var json = response.data[category];
+  Future<Map<String, dynamic>> deleteEventById(
+    String eventId, {
+    required String email,
+  }) async {
+    final response = await serverDio.delete(
+      '/api/v1/events/delete-event/$eventId',
+      options: Options(headers: {'x-email': email}),
+    );
+    return Map<String, dynamic>.from(response.data);
+  }
 
-    if (json != null) {
-      List<EventModel> eventPage = (json as List<dynamic>).map((e) {
-        return EventModel.fromJson(e);
-      }).toList();
-      return eventPage;
-    } else {
+  Future<Map<String, dynamic>> deleteEvent(String eventId) async {
+    final userEmail = LoginStore.userData['outlookEmail'] ?? '';
+    return deleteEventById(eventId, email: userEmail);
+  }
+
+  Future<List<EventModel>> getAdminEvents({
+    required String clubId,
+    String? status,
+  }) async {
+    try {
+      final queryParameters = <String, dynamic>{'club_id': clubId};
+      if (status != null && status.isNotEmpty) {
+        queryParameters['status'] = status;
+      }
+      final response = await serverDio.get(
+        '/api/v1/events/get-events',
+        queryParameters: queryParameters,
+      );
+      final json = response.data;
+      if (json['success'] == true && json['data'] is List) {
+        return (json['data'] as List<dynamic>)
+            .map((e) => EventModel.fromJson(e as Map<String, dynamic>))
+            .toList();
+      }
+      return [];
+    } catch (e) {
+      log('Error getting admin events: $e');
       return [];
     }
+  }
+
+  Future<List<EventModel>> getAllEvents({
+    String? feedType,
+    String? search,
+    String? date,
+    String? tags,
+    int? limit,
+    int? page,
+  }) async {
+    try {
+      final queryParameters = <String, dynamic>{};
+      if (feedType != null && feedType.isNotEmpty) {
+        queryParameters['feedType'] = feedType;
+      }
+      if (search != null && search.isNotEmpty) {
+        queryParameters['search'] = search;
+      }
+      if (date != null && date.isNotEmpty) {
+        queryParameters['date'] = date;
+      }
+      if (tags != null && tags.isNotEmpty && tags != 'All') {
+        queryParameters['tags'] = tags;
+      }
+      if (limit != null) {
+        queryParameters['limit'] = limit.toString();
+      }
+      if (page != null) {
+        queryParameters['page'] = page.toString();
+      }
+
+      final response = await serverDio.get(
+        '/api/v1/event-discovery',
+        queryParameters: queryParameters.isNotEmpty ? queryParameters : null,
+      );
+      final json = response.data;
+      if (json['success'] == true && json['data'] is List) {
+        return (json['data'] as List<dynamic>)
+            .map((e) => EventModel.fromJson(e as Map<String, dynamic>))
+            .toList();
+      }
+      return [];
+    } catch (e) {
+      log('Error fetching all events: $e');
+      return [];
+    }
+  }
+
+  /// Helper for pagination controllers in feed tabs
+  Future<List<EventModel>> getEventPage(
+    String category, {
+    int page = 1,
+    int limit = 10,
+  }) async {
+    if (category == 'Saved') {
+      final rollNo = LoginStore.userData['rollNo'] ?? '';
+      final email = LoginStore.userData['outlookEmail'] ?? '';
+      if (rollNo.isNotEmpty || email.isNotEmpty) {
+        return getUserLikedEvents(rollNo: rollNo, email: email);
+      }
+      return [];
+    }
+
+    final tags = (category == 'All' || category == 'Your Events') ? null : category;
+    return getAllEvents(
+      tags: tags,
+      page: page,
+      limit: limit,
+    );
+  }
+
+  Future<EventModel?> getEventDetails(String eventId, {String? studentId}) async {
+    try {
+      final queryParams = <String, dynamic>{};
+      if (studentId != null && studentId.isNotEmpty) {
+        queryParams['student_id'] = studentId;
+      }
+      final response = await serverDio.get(
+        '/api/v1/event-discovery/get-event-details/$eventId',
+        queryParameters: queryParams.isNotEmpty ? queryParams : null,
+      );
+      final json = response.data;
+      if (json['success'] == true && json['data'] is Map) {
+        return EventModel.fromJson(json['data'] as Map<String, dynamic>);
+      }
+      return null;
+    } catch (e) {
+      log('Error getting event details: $e');
+      return null;
+    }
+  }
+
+  Future<List<EventModel>> getUserLikedEvents({
+    required String rollNo,
+    required String email,
+  }) async {
+    try {
+      final response = await serverDio.get(
+        '/api/v1/event-discovery/liked',
+        queryParameters: {
+          'rollNo': rollNo,
+          'email': email,
+        },
+      );
+      final json = response.data;
+      if (json['success'] == true && json['data'] is List) {
+        return (json['data'] as List<dynamic>)
+            .map((e) => EventModel.fromJson(e as Map<String, dynamic>))
+            .toList();
+      }
+      return [];
+    } catch (e) {
+      log('Error getting user liked events: $e');
+      return [];
+    }
+  }
+
+  Future<StudentEventInteractionModel?> toggleLikeEvent({
+    required String rollNo,
+    required String email,
+    required String eventId,
+    required bool like,
+  }) async {
+    try {
+      final response = await serverDio.post(
+        '/api/v1/students/like-event',
+        queryParameters: {
+          'rollNo': rollNo,
+          'email': email,
+          'event_id': eventId,
+        },
+        data: {'like': like},
+      );
+      final json = response.data;
+      if (json['interaction'] != null && json['interaction'] is Map) {
+        return StudentEventInteractionModel.fromJson(
+            json['interaction'] as Map<String, dynamic>);
+      }
+      return null;
+    } catch (e) {
+      log('Error toggling like event: $e');
+      return null;
+    }
+  }
+
+  Future<Map<String, dynamic>> submitFeedback({
+    required String rollNo,
+    required String email,
+    required String eventId,
+    required EventFeedback feedback,
+  }) async {
+    final response = await serverDio.post(
+      '/api/v1/students/submit-feedback',
+      queryParameters: {
+        'rollNo': rollNo,
+        'email': email,
+        'event_id': eventId,
+      },
+      data: feedback.toJson(),
+    );
+    return Map<String, dynamic>.from(response.data);
+  }
+
+  Future<List<StudentEventInteractionModel>> getEventFeedback(String eventId) async {
+    try {
+      final response = await serverDio.get(
+        '/api/v1/students/get-feedback',
+        queryParameters: {'event_id': eventId},
+      );
+      final json = response.data;
+      if (json['success'] == true && json['data'] is List) {
+        return (json['data'] as List<dynamic>)
+            .map((e) => StudentEventInteractionModel.fromJson(
+                e as Map<String, dynamic>))
+            .toList();
+      }
+      return [];
+    } catch (e) {
+      log('Error getting event feedback: $e');
+      return [];
+    }
+  }
+
+  /// Admin lookup: checks admin status and returns clubs for the user
+  Future<Admin?> getAdmins() async {
+    try {
+      final response = await serverDio.get('/api/v1/admin/me');
+      if (response.data is Map<String, dynamic>) {
+        return Admin.fromJson(Map<String, dynamic>.from(response.data));
+      }
+    } catch (_) {
+      // Backend /api/v1/admin/me route not yet deployed on server (see backend_requirements.md)
+    }
+
+    // Default admin structure fallback matching boards and clubs
+    final email = LoginStore.userData['outlookEmail']?.toString() ?? '';
+    return Admin(clubs: [
+      Club(
+        name: "Technical Board",
+        members: ClubMembers(
+          admins: [if (email.isNotEmpty) email],
+          clubsOrgs: ["Coding Club", "Robotics Club", "Aeromodelling Club", "Electronics Club"],
+        ),
+      ),
+      Club(
+        name: "Cultural Board",
+        members: ClubMembers(
+          admins: [if (email.isNotEmpty) email],
+          clubsOrgs: ["Octaves", "Cadence", "Anchorenza", "Expressions"],
+        ),
+      ),
+      Club(
+        name: "Sports Board",
+        members: ClubMembers(
+          admins: [if (email.isNotEmpty) email],
+          clubsOrgs: ["Football", "Cricket", "Badminton", "Basketball", "Athletics"],
+        ),
+      ),
+      Club(
+        name: "Students' Web Committee",
+        members: ClubMembers(
+          admins: [if (email.isNotEmpty) email],
+          clubsOrgs: ["SWC"],
+        ),
+      ),
+    ]);
   }
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -2,6 +2,7 @@ import 'package:onestop_dev/pages/buy_sell/bns_home.dart';
 import 'package:onestop_dev/pages/complaints/complaints_page.dart';
 import 'package:onestop_dev/pages/contact/contact.dart';
 import 'package:onestop_dev/pages/elections/election_login.dart';
+import 'package:onestop_dev/pages/events/events_home_page.dart';
 import 'package:onestop_dev/pages/events_feed/events_appbar.dart';
 import 'package:onestop_dev/pages/food/mess_opi_form.dart';
 import 'package:onestop_dev/pages/food/mess_subscription_change_form.dart';
@@ -24,6 +25,7 @@ import 'package:onestop_dev/pages/timetable/timetable_page.dart';
 import 'package:onestop_dev/pages/upsp/upsp.dart';
 // import 'package:path/path.dart';
 import 'package:onestop_dev/pages/profile/profile_page.dart';
+
 final routes = {
   BlockedPage.id: (context) => const BlockedPage(),
   IRBSPage.id: (context) => const IRBSPage(),
@@ -47,6 +49,7 @@ final routes = {
   ElectionLoginWebView.id: (context) => const ElectionLoginWebView(),
   GateLogPage.id: (context) => const GateLogPage(),
   TimetablePage.id: (context) => const TimetablePage(),
+  EventsHomePage.id: (context) => const EventsHomePage(),
   EventsScreenWrapper.id: (context) => const EventsScreenWrapper(),
   LibraryTokenScreen.id: (context) => const LibraryTokenScreen(),
   ProfilePage.id: (context) => const ProfilePage(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -262,10 +262,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -756,14 +756,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.34"
-  flutter_riverpod:
-    dependency: transitive
-    description:
-      name: flutter_riverpod
-      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.6.1"
   flutter_staggered_grid_view:
     dependency: transitive
     description:
@@ -846,15 +838,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
-  gate_log:
-    dependency: "direct main"
-    description:
-      path: "packages/gate_log"
-      ref: redesign
-      resolved-ref: "9a67e089805dbbe3d9abc88860446f24364502d9"
-      url: "https://github.com/swciitg/gatelog_onestop.git"
-    source: git
-    version: "0.0.1"
   geoclue:
     dependency: transitive
     description:
@@ -1139,10 +1122,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -1154,11 +1137,9 @@ packages:
   irbs:
     dependency: "direct main"
     description:
-      path: "packages/irbs"
-      ref: redesign
-      resolved-ref: "2ffe13d9272367287a7a5430f9876d10338a7170"
-      url: "https://github.com/swciitg/irbs.git"
-    source: git
+      path: "../irbs/packages/irbs"
+      relative: true
+    source: path
     version: "1.0.0"
   js:
     dependency: transitive
@@ -1208,15 +1189,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  lib_token:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: redesign
-      resolved-ref: "144e792f33d38272686da5c2941d0818c8785403"
-      url: "https://github.com/swciitg/lib_token.git"
-    source: git
-    version: "0.0.1"
   lints:
     dependency: transitive
     description:
@@ -1261,26 +1233,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -1341,11 +1313,9 @@ packages:
   onestop_ui:
     dependency: "direct main"
     description:
-      path: "packages/onestop_ui"
-      ref: dev
-      resolved-ref: "991770c10147a2169797583c16b29485ae25c024"
-      url: "https://github.com/swciitg/onestop_ui.git"
-    source: git
+      path: "../onestop_ui/packages/onestop_ui"
+      relative: true
+    source: path
     version: "0.0.1"
   os_detect:
     dependency: transitive
@@ -1515,14 +1485,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  qr_flutter:
-    dependency: transitive
-    description:
-      name: qr_flutter
-      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.0"
   quick_actions:
     dependency: "direct main"
     description:
@@ -1555,14 +1517,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  riverpod:
-    dependency: transitive
-    description:
-      name: riverpod
-      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.6.1"
   rxdart:
     dependency: transitive
     description:
@@ -1588,62 +1542,6 @@ packages:
       url: "https://github.com/swciitg/gc_scoreboard.git"
     source: git
     version: "0.0.0"
-  screen_brightness:
-    dependency: transitive
-    description:
-      name: screen_brightness
-      sha256: "5f70754028f169f059fdc61112a19dcbee152f8b293c42c848317854d650cba3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.7"
-  screen_brightness_android:
-    dependency: transitive
-    description:
-      name: screen_brightness_android
-      sha256: d34f5321abd03bc3474f4c381f53d189117eba0b039eac1916aa92cca5fd0a96
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.3"
-  screen_brightness_ios:
-    dependency: transitive
-    description:
-      name: screen_brightness_ios
-      sha256: "2493953340ecfe8f4f13f61db50ce72533a55b0bbd58ba1402893feecf3727f5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
-  screen_brightness_macos:
-    dependency: transitive
-    description:
-      name: screen_brightness_macos
-      sha256: "4edf330ad21078686d8bfaf89413325fbaf571dcebe1e89254d675a3f288b5b9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.1"
-  screen_brightness_ohos:
-    dependency: transitive
-    description:
-      name: screen_brightness_ohos
-      sha256: a93a263dcd39b5c56e589eb495bcd001ce65cdd96ff12ab1350683559d5c5bb7
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
-  screen_brightness_platform_interface:
-    dependency: transitive
-    description:
-      name: screen_brightness_platform_interface
-      sha256: "737bd47b57746bc4291cab1b8a5843ee881af499514881b0247ec77447ee769c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
-  screen_brightness_windows:
-    dependency: transitive
-    description:
-      name: screen_brightness_windows
-      sha256: d3518bf0f5d7a884cee2c14449ae0b36803802866de09f7ef74077874b6b2448
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   sembast:
     dependency: "direct main"
     description:
@@ -1817,14 +1715,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
-  state_notifier:
-    dependency: transitive
-    description:
-      name: state_notifier
-      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:
@@ -1917,10 +1807,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.12"
   timeago:
     dependency: "direct main"
     description:
@@ -2069,10 +1959,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   version:
     dependency: transitive
     description:
@@ -2194,5 +2084,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
+  dart: ">=3.11.0-0 <4.0.0"
   flutter: ">=3.38.0"


### PR DESCRIPTION
## **CodeAnt-AI Description**
Launch a live events homepage with clubs, search, and event actions

### What Changed
- Replaced placeholder event content with live sections for today’s, trending, interest-based, saved, and exploratory events.
- Added event search by name, club, tags, and description, including remote results and clear loading, empty, and retry states.
- Users can open full event details, mark events as interested or registered, view updated counts, and contact event organizers.
- Added a Clubs & Fests page with category filters, club details, team contacts, and call, text, and email actions.
- Updated event data handling to support the current event API while retaining compatibility with existing event screens.
- Added cached images, loading placeholders, safer missing-data fallbacks, compact counts, and accurate single-day or multi-day date ranges.
- Added paginated event feeds and safer admin and event creation flows, including support for users without assigned clubs.

### Impact
`✅ Live event discovery`
`✅ Searchable events and clubs`
`✅ Working interest, registration, and organizer contact actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
